### PR TITLE
Fix connection test

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
@@ -306,7 +306,7 @@ public class RocketChatNotifier extends Notifier {
                                            @QueryParameter("rocketChannel") final String channel,
                                            @QueryParameter("rocketBuildServerUrl") final String buildServerUrl) throws FormException {
       try {
-        String targetServerUrl = rocketServerURL;
+        String targetServerUrl = rocketServerURL + RocketClientImpl.API_PATH;
         if (StringUtils.isEmpty(targetServerUrl)) {
           targetServerUrl = this.rocketServerUrl;
         }


### PR DESCRIPTION
The /api/ fragment is added when running notifications. It is however not added when testing the connection. This fix makes sure the serverUrl is appended with /api/ in both cases.