### PR TITLE
check passed rocketServer URL string

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
@@ -308,7 +308,7 @@ public class RocketChatNotifier extends Notifier {
                                            @QueryParameter("rocketBuildServerUrl") final String buildServerUrl) throws FormException {
       try {
         String targetServerUrl = rocketServerURL + RocketClientImpl.API_PATH;
-        if (StringUtils.isEmpty(targetServerUrl)) {
+        if (StringUtils.isEmpty(rocketServerURL)) {
           targetServerUrl = this.rocketServerUrl;
         }
         String targetUsername = username;


### PR DESCRIPTION
Do not check "null" + RocketClientImpl.API_PATH, because it never will be empty.

This might partial fix for https://issues.jenkins-ci.org/browse/JENKINS-39690