### PR TITLE
Fix for JENKINS-39690

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
@@ -193,6 +193,13 @@ public class RocketChatNotifier extends Notifier {
 
   @Override
   public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+    Map<Descriptor<Publisher>, Publisher> map = build.getProject().getPublishersList().toMap();
+    for (Publisher publisher : map.values()) {
+      if (publisher instanceof RocketChatNotifier) {
+        LOGGER.info("Invoking Completed...");
+        new ActiveNotifier((RocketChatNotifier) publisher, listener).completed(build);
+      }
+    }
     return true;
   }
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-39690

It seems that calling ActiveNotifier::completed got missing somewhere, this should fix it and making this plugin usable again.