### PR TITLE
fixed empty config-text-box for rocket server URL

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
@@ -296,14 +296,14 @@ public class RocketChatNotifier extends Notifier {
       return "RocketChat Notifications";
     }
 
-    public FormValidation doTestConnection(@QueryParameter("rocketServer") final String rocketServerURL,
+    public FormValidation doTestConnection(@QueryParameter("rocketServerUrl") final String rocketServerUrl,
                                            @QueryParameter("rocketUsername") final String username,
                                            @QueryParameter("rocketPassword") final String password,
                                            @QueryParameter("rocketChannel") final String channel,
                                            @QueryParameter("rocketBuildServerUrl") final String buildServerUrl) throws FormException {
       try {
-        String targetServerUrl = rocketServerURL + RocketClientImpl.API_PATH;
-        if (StringUtils.isEmpty(rocketServerURL)) {
+        String targetServerUrl = rocketServerUrl + RocketClientImpl.API_PATH;
+        if (StringUtils.isEmpty(rocketServerUrl)) {
           targetServerUrl = this.rocketServerUrl;
         }
         String targetUsername = username;

--- a/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/global.jelly
@@ -15,7 +15,7 @@
   -->
 <f:section title="Global RocketChat Notifier Settings" name="rocket">
     <f:entry title="Rocket Server URL">
-        <f:textbox field="rocketServerURL" name="rocketServer" value="${descriptor.getRocketServerURL()}" />
+        <f:textbox field="rocketServerUrl" name="rocketServerUrl" value="${descriptor.getRocketServerUrl()}" />
     </f:entry>
     <f:entry title="Login Username">
         <f:textbox field="username" name="rocketUsername" value="${descriptor.getUsername()}" />
@@ -31,6 +31,6 @@
     </f:entry>
     <f:validateButton
         title="${%Test Connection}" progress="${%Testing...}"
-        method="testConnection" with="rocketServer,rocketUsername,rocketPassword,rocketChannel,rocketBuildServerUrl" />
+        method="testConnection" with="rocketServerUrl,rocketUsername,rocketPassword,rocketChannel,rocketBuildServerUrl" />
   </f:section>
 </j:jelly>


### PR DESCRIPTION
Hello,

the rocket server url configuration is always blank while initializing the server config screen. This pull request will fix this issue.

Greetings,
Marco