### PR TITLE
added support for java.net proxy properties

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatClientCallBuilder.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatClientCallBuilder.java
@@ -53,18 +53,13 @@ public class RocketChatClientCallBuilder {
 
   }
 
-  private boolean isSsl() {
-    URI serverUri = URI.create(this.serverUrl);
-    return serverUri.getScheme().equals("https");
-  }
-
   private boolean hasProxyEnvironment() {
     return !this.getProxy().isEmpty();
   }
 
   private String getProxy() {
     Environment env = new Environment();
-    return this.isSsl() ? env.getHttpsProxy() : env.getHttpProxy();
+    return env.getProxy(this.serverUrl);
   }
 
   protected Response buildCall(RocketChatRestApiV1 call) throws IOException {

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/utils/Environment.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/utils/Environment.java
@@ -1,16 +1,101 @@
 package jenkins.plugins.rocketchatnotifier.utils;
 
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 public class Environment {
 
+  static final String JAVA_NET_PROXY_HOST_POSTFIX = ".proxyHost";
+  static final String JAVA_NET_PROXY_PORT_POSTFIX = ".proxyPort";
+  static final String JAVA_NET_NON_PROXY_HOSTS_POSTFIX = ".nonProxyHosts";
+  static final String ENV_PROXY_POSTFIX = "_proxy";
+  static final String ENV_NO_PROXY = "no_proxy";
 
-  public String getHttpProxy() {
-    String value = System.getenv("http_proxy");
-    return value == null ? "" : value;
+  /**
+   * <p>Determines the proxy to use for the given url.</p>
+   * <p>With priority the system properties</p>
+   * <ul>
+   *   <li>http.proxyHost</li>
+   *   <li>http.proxyPort</li>
+   *   <li>https.nonProxyHosts</li>
+   *   <li>https.proxyHost</li>
+   *   <li>https.proxyPort</li>
+   *   <li>https.nonProxyHosts</li>
+   * </ul>
+   * <p>will be read and handles theme as described in
+   * <a href="https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html">JAVA network properties</a>,
+   * except for nonProxyHosts will only used domain names.</p>
+   *
+   * <p>After this the system environment variables</p>
+   * <ul>
+   *   <li>http_proxy</li>
+   *   <li>https_proxy</li>
+   *   <li>no_proxy</li>
+   * </ul>
+   *
+   * @param url an url
+   * @return the proxy to use or an empty string
+   */
+  public String getProxy(String url) {
+    URI serverUri = URI.create(url);
+    String scheme = serverUri.getScheme();
+
+    Set<String> nonProxies = getNoProxyForScheme(scheme);
+    boolean resolveProxy = true;
+    for (String nonProxy : nonProxies) {
+      // following test is very simple. According to
+      // https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html
+      // we should check for IP ranges, too. But this is something for a future feature request ;)
+      if (serverUri.getHost().equalsIgnoreCase(nonProxy)) {
+        resolveProxy = false;
+        break;
+      }
+    }
+
+    if (resolveProxy) {
+      return getProxyForScheme(scheme);
+    }
+    return "";
   }
 
-  public String getHttpsProxy() {
-    String value = System.getenv("https_proxy");
-    return value == null ? "" : value;
+  private String getProxyForScheme(String scheme) {
+    // see https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html
+    String host = System.getProperty(scheme + JAVA_NET_PROXY_HOST_POSTFIX);
+    String port = System.getProperty(scheme + JAVA_NET_PROXY_PORT_POSTFIX);
+    if (host != null && port != null) {
+      return String.format("%s:%s", host, port);
+    }
+
+    String value = System.getenv(scheme + ENV_PROXY_POSTFIX);
+    if (value != null) {
+      return value;
+    }
+
+    return "";
   }
 
+  private Set<String> getNoProxyForScheme(String scheme) {
+    // see https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html
+    String value = System.getProperty(scheme + JAVA_NET_NON_PROXY_HOSTS_POSTFIX);
+    if (value != null) {
+      return splitEnvValue(value, "\\|");
+    }
+
+    value = System.getenv(ENV_NO_PROXY);
+    if (value != null) {
+      return splitEnvValue(value, ",");
+    }
+
+    return Collections.emptySet();
+  }
+
+  private Set<String> splitEnvValue(String value, String delimiter) {
+    Set<String> noProxies = new HashSet<>();
+    for (String noProxy : value.split(delimiter)) {
+      noProxies.add(noProxy.trim());
+    }
+    return noProxies;
+  }
 }

--- a/src/test/java/jenkins/plugins/rocketchatnotifier/utils/EnvironmentTest.java
+++ b/src/test/java/jenkins/plugins/rocketchatnotifier/utils/EnvironmentTest.java
@@ -1,0 +1,93 @@
+package jenkins.plugins.rocketchatnotifier.utils;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Because of the immutable nature of System.getenv() this, test will only check the properties that can be set
+ * by System.setProperty()
+ */
+public class EnvironmentTest {
+
+  private static final String SAMPLE_PROXY_HOST = "proxy.local.lan";
+  private static final String SAMPLE_PROXY_PORT = "8888";
+  private static final String SAMPLE_PROXY = SAMPLE_PROXY_HOST + ":" + SAMPLE_PROXY_PORT;
+
+  private Environment env;
+
+  @Before
+  public void setup() {
+    // we assume that the environment properties were not set, otherwise this will lead to an
+    // unexpected behaviour
+    assertNull(System.getenv("http" + Environment.ENV_PROXY_POSTFIX));
+    assertNull(System.getenv("https" + Environment.ENV_PROXY_POSTFIX));
+    assertNull(System.getenv(Environment.ENV_NO_PROXY));
+
+    for (String scheme : Arrays.asList("http", "https")) {
+      System.clearProperty(scheme + Environment.JAVA_NET_NON_PROXY_HOSTS_POSTFIX);
+      System.clearProperty(scheme + Environment.JAVA_NET_PROXY_HOST_POSTFIX);
+      System.clearProperty(scheme + Environment.JAVA_NET_PROXY_PORT_POSTFIX);
+    }
+    this.env = new Environment();
+  }
+
+  @Test
+  public void noProxyConfigured() {
+    assertTrue(isBlank(this.env.getProxy("http://www.google.de")));
+    assertTrue(isBlank(this.env.getProxy("https://www.google.de")));
+  }
+
+  @Test
+  public void httpPoxyConfigured() {
+    // only http properties set
+    System.setProperty("http" + Environment.JAVA_NET_PROXY_HOST_POSTFIX, SAMPLE_PROXY_HOST);
+    System.setProperty("http" + Environment.JAVA_NET_PROXY_PORT_POSTFIX, SAMPLE_PROXY_PORT);
+    assertEquals(this.env.getProxy("http://www.google.de"), SAMPLE_PROXY);
+    assertTrue(isBlank(this.env.getProxy("https://www.google.de")));
+
+    // no-https-property set
+    System.setProperty("https" + Environment.JAVA_NET_NON_PROXY_HOSTS_POSTFIX, "www.google.de|www.apache.org");
+    assertEquals(this.env.getProxy("http://www.google.de"), SAMPLE_PROXY);
+    assertTrue(isBlank(this.env.getProxy("https://www.google.de")));
+    assertEquals(this.env.getProxy("http://www.apache.org"), SAMPLE_PROXY);
+    assertTrue(isBlank(this.env.getProxy("https://www.apache.org")));
+
+    // no-http-property set, too
+    System.setProperty("http" + Environment.JAVA_NET_NON_PROXY_HOSTS_POSTFIX, "www.google.de|www.apache.org");
+    assertTrue(isBlank(this.env.getProxy("http://www.google.de")));
+    assertTrue(isBlank(this.env.getProxy("https://www.google.de")));
+    assertTrue(isBlank(this.env.getProxy("http://www.apache.org")));
+    assertTrue(isBlank(this.env.getProxy("https://www.apache.org")));
+  }
+
+  @Test
+  public void httpsPoxyConfigured() {
+    // only https properties set
+    System.setProperty("https" + Environment.JAVA_NET_PROXY_HOST_POSTFIX, SAMPLE_PROXY_HOST);
+    System.setProperty("https" + Environment.JAVA_NET_PROXY_PORT_POSTFIX, SAMPLE_PROXY_PORT);
+    assertEquals(this.env.getProxy("https://www.google.de"), SAMPLE_PROXY);
+    assertTrue(isBlank(this.env.getProxy("http://www.google.de")));
+
+    // no-http-property set
+    System.setProperty("http" + Environment.JAVA_NET_NON_PROXY_HOSTS_POSTFIX, "www.google.de|www.apache.org");
+    assertEquals(this.env.getProxy("https://www.google.de"), SAMPLE_PROXY);
+    assertTrue(isBlank(this.env.getProxy("http://www.google.de")));
+    assertEquals(this.env.getProxy("https://www.apache.org"), SAMPLE_PROXY);
+    assertTrue(isBlank(this.env.getProxy("http://www.apache.org")));
+
+    // no-https-property set, too
+    System.setProperty("https" + Environment.JAVA_NET_NON_PROXY_HOSTS_POSTFIX, "www.google.de|www.apache.org");
+    assertTrue(isBlank(this.env.getProxy("https://www.google.de")));
+    assertTrue(isBlank(this.env.getProxy("http://www.google.de")));
+    assertTrue(isBlank(this.env.getProxy("https://www.apache.org")));
+    assertTrue(isBlank(this.env.getProxy("http://www.apache.org")));
+
+  }
+}


### PR DESCRIPTION
Hello,

I've added addtitional support for the commonly known proxy-properties as described in 

https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html

Greetings,
Marco