### PR TITLE
Add support for posting to webhook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,16 @@
       <version>${workflow.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>1.25</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>plain-credentials</artifactId>
+      <version>1.1</version>
+    </dependency>
 
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
@@ -7,25 +7,38 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
+import hudson.security.ACL;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
+
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
+import com.fasterxml.jackson.core.JsonParseException;
+
 import sun.security.validator.ValidatorException;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
 
 public class RocketChatNotifier extends Notifier {
 
@@ -49,6 +62,7 @@ public class RocketChatNotifier extends Notifier {
   private boolean includeCustomMessage;
   private String customMessage;
   private String webhookToken;
+  private String webhookTokenCredentialId;
 
   @Override
   public DescriptorImpl getDescriptor() {
@@ -120,13 +134,17 @@ public class RocketChatNotifier extends Notifier {
   public String getWebhookToken() {
     return webhookToken;
   }
+  
+  public String getWebhookTokenCredentialId() {
+    return webhookTokenCredentialId;
+  }
 
   @DataBoundConstructor
   public RocketChatNotifier(final String rocketServerUrl, final boolean trustSSL, final String username, final String password, final String channel, final String buildServerUrl,
                             final boolean startNotification, final boolean notifyAborted, final boolean notifyFailure,
                             final boolean notifyNotBuilt, final boolean notifySuccess, final boolean notifyUnstable, final boolean notifyBackToNormal,
                             final boolean notifyRepeatedFailure, final boolean includeTestSummary, CommitInfoChoice commitInfoChoice,
-                            boolean includeCustomMessage, String customMessage, String webhookToken) {
+                            boolean includeCustomMessage, String customMessage, String webhookToken, String tokenCredentialId) {
     super();
     this.rocketServerUrl = rocketServerUrl;
     this.trustSSL = trustSSL;
@@ -147,6 +165,7 @@ public class RocketChatNotifier extends Notifier {
     this.includeCustomMessage = includeCustomMessage;
     this.customMessage = customMessage;
     this.webhookToken = webhookToken;
+    this.webhookTokenCredentialId = tokenCredentialId;
   }
 
   public BuildStepMonitor getRequiredMonitorService() {
@@ -182,8 +201,8 @@ public class RocketChatNotifier extends Notifier {
     username = env.expand(username);
     password = env.expand(password);
 
-    if (!StringUtils.isEmpty(webhookToken)) {
-      return new RocketClientWebhookImpl(serverUrl, trustSSL, webhookToken);
+    if (!StringUtils.isEmpty(webhookToken) || !StringUtils.isEmpty(webhookTokenCredentialId)) {
+      return new RocketClientWebhookImpl(serverUrl, trustSSL, webhookToken, webhookTokenCredentialId);
     }
     return new RocketClientImpl(serverUrl, trustSSL, username, password, channel);
   }
@@ -224,6 +243,7 @@ public class RocketChatNotifier extends Notifier {
     private String channel;
     private String buildServerUrl;
     private String webhookToken;
+    private String webhookTokenCredentialId;
 
     public static final CommitInfoChoice[] COMMIT_INFO_CHOICES = CommitInfoChoice.values();
 
@@ -254,6 +274,11 @@ public class RocketChatNotifier extends Notifier {
     public String getWebhookToken() {
       return webhookToken;
     }
+    
+    public String getWebhookTokenCredentialId() {
+      return webhookTokenCredentialId;
+    }
+
 
     public String getBuildServerUrl() {
       if (buildServerUrl == null || buildServerUrl.equalsIgnoreCase("")) {
@@ -289,9 +314,10 @@ public class RocketChatNotifier extends Notifier {
         boolean includeCustomMessage = "on".equals(sr.getParameter("includeCustomMessage"));
         String customMessage = sr.getParameter("customMessage");
         String webhookToken = sr.getParameter("webhookToken");
+        String webhookTokenCredentialId = sr.getParameter("tokenCredentialId");
         return new RocketChatNotifier(rocketServerUrl, trustSSL, username, password, channel, buildServerUrl, startNotification, notifyAborted,
           notifyFailure, notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, notifyRepeatedFailure,
-          includeTestSummary, commitInfoChoice, includeCustomMessage, customMessage, webhookToken);
+          includeTestSummary, commitInfoChoice, includeCustomMessage, customMessage, webhookToken, webhookTokenCredentialId);
       }
       return null;
     }
@@ -312,6 +338,7 @@ public class RocketChatNotifier extends Notifier {
         buildServerUrl = buildServerUrl + "/";
       }
       webhookToken = sr.getParameter("webhookToken");
+      webhookTokenCredentialId = sr.getParameter("tokenCredentialId");
       save();
       return super.configure(sr, formData);
     }
@@ -327,7 +354,8 @@ public class RocketChatNotifier extends Notifier {
                                            @QueryParameter("rocketPassword") final String password,
                                            @QueryParameter("rocketChannel") final String channel,
                                            @QueryParameter("rocketBuildServerUrl") final String buildServerUrl,
-                                           @QueryParameter("webhookToken") final String webhookToken) throws FormException {
+                                           @QueryParameter("webhookToken") final String webhookToken,
+                                           @QueryParameter("tokenCredentialId") final String webhookTokenCredentialId) throws FormException {
       try {
         String targetServerUrl = rocketServerUrl + RocketClientImpl.API_PATH;
         if (StringUtils.isEmpty(rocketServerUrl)) {
@@ -357,10 +385,14 @@ public class RocketChatNotifier extends Notifier {
         if (StringUtils.isEmpty(targetWebhookToken)) {
           targetWebhookToken = this.webhookToken;
         }
+        String targetWebhookTokenCredentialId = webhookTokenCredentialId;
+        if (StringUtils.isEmpty(targetWebhookTokenCredentialId)) {
+          targetWebhookTokenCredentialId = this.webhookTokenCredentialId;
+        }
         
         RocketClient rocketChatClient;
-        if (!StringUtils.isEmpty(targetWebhookToken)){
-          rocketChatClient = new RocketClientWebhookImpl(targetServerUrl, targetTrustSSL, targetWebhookToken);
+        if (!StringUtils.isEmpty(targetWebhookToken) || !StringUtils.isEmpty(targetWebhookTokenCredentialId)){
+          rocketChatClient = new RocketClientWebhookImpl(targetServerUrl, targetTrustSSL, targetWebhookToken, targetWebhookTokenCredentialId);
         } else {
           rocketChatClient = new RocketClientImpl(targetServerUrl, targetTrustSSL, targetUsername, targetPassword, targetChannel);
         }
@@ -379,6 +411,28 @@ public class RocketChatNotifier extends Notifier {
         LOGGER.log(Level.SEVERE, "Client error during trying to send rocket message", e);
         return FormValidation.error(e, "Client error - Could not send message");
       }
+    }
+
+    public ListBoxModel doFillTokenCredentialIdItems() {
+      if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+        return new ListBoxModel();
+      }
+      return new StandardListBoxModel()
+              .withEmptySelection()
+              .withAll(lookupCredentials(
+                      StringCredentials.class,
+                      Jenkins.getInstance(),
+                      ACL.SYSTEM,
+                      Collections.<DomainRequirement>emptyList())
+              );
+    }
+  
+    //WARN users that they should not use the plain/exposed token, but rather the token credential id
+    public FormValidation doCheckWebhookToken(@QueryParameter String value) {
+      if (StringUtils.isEmpty(value)) {
+        return FormValidation.ok();
+      }
+      return FormValidation.warning("Exposing your Integration Token is a security risk. Please use the Webhook Token Credential ID");
     }
   }
 

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/RocketClientWebhookImpl.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/RocketClientWebhookImpl.java
@@ -1,11 +1,21 @@
 package jenkins.plugins.rocketchatnotifier;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+
+import hudson.security.ACL;
+import jenkins.model.Jenkins;
 import jenkins.plugins.rocketchatnotifier.rocket.RocketChatClient;
 import jenkins.plugins.rocketchatnotifier.rocket.RocketChatClientImpl;
 import sun.security.validator.ValidatorException;
@@ -16,8 +26,8 @@ public class RocketClientWebhookImpl implements RocketClient {
 
   private RocketChatClient client;
 
-  public RocketClientWebhookImpl(String serverUrl, boolean trustSSL, String token) {
-    client = new RocketChatClientImpl(serverUrl, trustSSL, token);
+  public RocketClientWebhookImpl(String serverUrl, boolean trustSSL, String token, String tokenCredentialId) {
+    client = new RocketChatClientImpl(serverUrl, trustSSL, getTokenToUse(tokenCredentialId, token));
   }
 
   public boolean publish(String message) {
@@ -50,7 +60,8 @@ public class RocketClientWebhookImpl implements RocketClient {
   }
 
   @Override
-  public boolean publish(final String message, final String emoji, final String avatar, final List<Map<String, Object>> attachments) {
+  public boolean publish(final String message, final String emoji, final String avatar,
+      final List<Map<String, Object>> attachments) {
     try {
       LOGGER.fine("Starting sending message to webhook");
       this.client.send("", message, emoji, avatar, attachments);
@@ -63,9 +74,30 @@ public class RocketClientWebhookImpl implements RocketClient {
       return false;
     }
   }
-  
+
   @Override
   public void validate() throws ValidatorException, IOException {
     this.client.send("", "Test message from Jenkins via Webhook");
+  }
+
+  private String getTokenToUse(String tokenCredentialId, String tokenString) {
+    if (!StringUtils.isEmpty(tokenCredentialId)) {
+      StringCredentials credentials = lookupCredentials(tokenCredentialId);
+      if (credentials != null) {
+        LOGGER.fine("Using Integration Token Credential ID.");
+        return credentials.getSecret().getPlainText();
+      }
+    }
+
+    LOGGER.fine("Using Integration Token.");
+
+    return tokenString;
+  }
+
+  private StringCredentials lookupCredentials(String credentialId) {
+    List<StringCredentials> credentials = com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials(
+        StringCredentials.class, Jenkins.getInstance(), ACL.SYSTEM, Collections.<DomainRequirement>emptyList());
+    CredentialsMatcher matcher = CredentialsMatchers.withId(credentialId);
+    return CredentialsMatchers.firstOrNull(credentials, matcher);
   }
 }

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/RocketClientWebhookImpl.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/RocketClientWebhookImpl.java
@@ -1,0 +1,71 @@
+package jenkins.plugins.rocketchatnotifier;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import jenkins.plugins.rocketchatnotifier.rocket.RocketChatClient;
+import jenkins.plugins.rocketchatnotifier.rocket.RocketChatClientImpl;
+import sun.security.validator.ValidatorException;
+
+public class RocketClientWebhookImpl implements RocketClient {
+
+  private static final Logger LOGGER = Logger.getLogger(RocketClientImpl.class.getName());
+
+  private RocketChatClient client;
+
+  public RocketClientWebhookImpl(String serverUrl, boolean trustSSL, String token) {
+    client = new RocketChatClientImpl(serverUrl, trustSSL, token);
+  }
+
+  public boolean publish(String message) {
+    try {
+      LOGGER.fine("Starting sending message to webhook");
+      this.client.send("", message);
+      return true;
+    } catch (IOException e) {
+      LOGGER.log(Level.SEVERE, "I/O error error during publishing message", e);
+      return false;
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, "Unknown error error during publishing message", e);
+      return false;
+    }
+  }
+
+  @Override
+  public boolean publish(final String message, final String emoji, final String avatar) {
+    try {
+      LOGGER.fine("Starting sending message to webhook");
+      this.client.send("", message, emoji, avatar);
+      return true;
+    } catch (IOException e) {
+      LOGGER.log(Level.SEVERE, "I/O error error during publishing message", e);
+      return false;
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, "Unknown error error during publishing message", e);
+      return false;
+    }
+  }
+
+  @Override
+  public boolean publish(final String message, final String emoji, final String avatar, final List<Map<String, Object>> attachments) {
+    try {
+      LOGGER.fine("Starting sending message to webhook");
+      this.client.send("", message, emoji, avatar, attachments);
+      return true;
+    } catch (IOException e) {
+      LOGGER.log(Level.SEVERE, "I/O error error during publishing message", e);
+      return false;
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, "Unknown error error during publishing message", e);
+      return false;
+    }
+  }
+  
+  @Override
+  public void validate() throws ValidatorException, IOException {
+    this.client.send("", "Test message from Jenkins via Webhook");
+  }
+}

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatBasicCallAuthentication.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatBasicCallAuthentication.java
@@ -1,0 +1,74 @@
+package jenkins.plugins.rocketchatnotifier.rocket;
+
+import java.io.IOException;
+
+import org.json.JSONObject;
+
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import com.mashape.unirest.request.HttpRequest;
+
+/**
+ * Authentication using username/ password
+ */
+public class RocketChatBasicCallAuthentication implements RocketChatCallAuthentication {
+  private final String serverUrl;
+  private final String user;
+  private final String password;
+  private String authToken = "";
+  private String userId = "";
+
+  public RocketChatBasicCallAuthentication(String serverUrl, String user, String password) {
+    super();
+    if (!serverUrl.endsWith("api/")) {
+      this.serverUrl = serverUrl + (serverUrl.endsWith("/") ? "" : "/") + "api/";
+    } else {
+      this.serverUrl = serverUrl;
+    }
+
+    this.user = user;
+    this.password = password;
+  }
+
+  @Override
+  public boolean isAuthenticated() {
+    return !authToken.isEmpty() && !userId.isEmpty();
+  }
+
+  @Override
+  public void doAuthentication() throws IOException {
+    HttpResponse<JsonNode> loginResult;
+    String apiURL = serverUrl + "v1/login";
+
+    try {
+      loginResult = Unirest.post(apiURL).field("user", user).field("password", password).asJson();
+    } catch (UnirestException e) {
+      throw new IOException("Please check if the server API " + apiURL + " is correct: " + e.getMessage(), e);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+
+    if (loginResult.getStatus() == 401)
+      throw new IOException("The username and password provided are incorrect.");
+
+    if (loginResult.getStatus() != 200)
+      throw new IOException("The login failed with a result of: " + loginResult.getStatus());
+
+    JSONObject data = loginResult.getBody().getObject().getJSONObject("data");
+    this.authToken = data.getString("authToken");
+    this.userId = data.getString("userId");
+  }
+
+  @Override
+  public String getUrlForRequest(RocketChatRestApiV1 call) {
+    return serverUrl + call.getMethodName();
+  }
+
+  @Override
+  public void addAuthenticationDataToRequest(HttpRequest request) {
+    request.header("X-Auth-Token", authToken);
+    request.header("X-User-Id", userId);
+  }
+}

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatCallAuthentication.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatCallAuthentication.java
@@ -1,0 +1,16 @@
+package jenkins.plugins.rocketchatnotifier.rocket;
+
+import java.io.IOException;
+
+import com.mashape.unirest.request.HttpRequest;
+
+public interface RocketChatCallAuthentication {
+
+  boolean isAuthenticated();
+
+  void doAuthentication() throws IOException;
+
+  String getUrlForRequest(RocketChatRestApiV1 call);
+
+  void addAuthenticationDataToRequest(HttpRequest request);
+}

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatClientCallBuilder.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatClientCallBuilder.java
@@ -48,6 +48,10 @@ public class RocketChatClientCallBuilder {
     this(new RocketChatBasicCallAuthentication(serverUrl, user, password), serverUrl, trustSSL);
   }
 
+  protected RocketChatClientCallBuilder(String serverUrl, boolean trustSSL, String webhookToken) {
+    this(new RocketChatWebhookAuthentication(serverUrl, webhookToken), serverUrl, trustSSL);
+  }
+
   protected RocketChatClientCallBuilder(RocketChatCallAuthentication authentication, String serverUrl,
       boolean trustSSL) {
     this.authentication = authentication;

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatWebhookAuthentication.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatWebhookAuthentication.java
@@ -1,0 +1,45 @@
+package jenkins.plugins.rocketchatnotifier.rocket;
+
+import java.io.IOException;
+import com.mashape.unirest.request.HttpRequest;
+
+public class RocketChatWebhookAuthentication implements RocketChatCallAuthentication {
+  private static final String HOOKS_PATH = "hooks/";
+
+  private String serverUrl;
+  private String webhookUrl;
+
+  public RocketChatWebhookAuthentication(String serverUrl, String webhookToken) {
+    super();
+    this.serverUrl = serverUrl + (serverUrl.endsWith("/") ? "" : "/");
+    this.webhookUrl = webhookToken.contains(HOOKS_PATH) ? webhookToken : (this.serverUrl + HOOKS_PATH + webhookToken);
+  }
+
+  @Override
+  public boolean isAuthenticated() {
+    // No authentication needed
+    return true;
+  }
+
+  @Override
+  public void doAuthentication() throws IOException {
+    // No authentication needed
+  }
+
+  @Override
+  public String getUrlForRequest(RocketChatRestApiV1 call) {
+    switch (call) {
+      case Info:
+        return serverUrl + "/api/" + call.getMethodName();
+      case PostMessage:
+        return webhookUrl;
+      default:
+        throw new UnsupportedOperationException("Unable to handle request " + call.name() + " using webhook");
+    }
+  }
+
+  @Override
+  public void addAuthenticationDataToRequest(HttpRequest request) {
+    // No authentication needed
+  }
+}

--- a/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/config.jelly
@@ -55,8 +55,12 @@
         <f:entry title="Project Channel" description="Comma separated list of rooms (e.g. #project) and / or persons (e.g. @john)">
             <f:textbox name="rocketChannel" value="${instance.getChannel()}"/>
         </f:entry>
+        <f:entry title="Incoming Webhook Token" description="Webhook token for posting messages. Overrides global authentication data and channel. ">
+            <f:textbox name="webhookToken" value="${instance.getWebhookToken()}"/>
+        </f:entry>
+        
         <f:validateButton
                 title="${%Test Connection}" progress="${%Testing...}"
-                method="testConnection" with="rocketChannel"/>
+                method="testConnection" with="rocketChannel,webhookToken"/>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry title="Notify Build Start">
         <f:checkbox name="rocketStartNotification" value="true" checked="${instance.getStartNotification()}"/>
     </f:entry>
@@ -55,12 +55,16 @@
         <f:entry title="Project Channel" description="Comma separated list of rooms (e.g. #project) and / or persons (e.g. @john)">
             <f:textbox name="rocketChannel" value="${instance.getChannel()}"/>
         </f:entry>
-        <f:entry title="Incoming Webhook Token" description="Webhook token for posting messages. Overrides global authentication data and channel. ">
-            <f:textbox name="webhookToken" value="${instance.getWebhookToken()}"/>
+        <f:entry title="Incoming Webhook Token" description="Webhook token for posting messages. Overrides global authentication data and channel.">
+            <f:textbox field="webhookToken" name="webhookToken" value="${instance.getWebhookToken()}"/>
+        </f:entry>
+        
+        <f:entry title="Webhook Token Credential ID" field="tokenCredentialId" name="tokenCredentialId" description="Webhook token as Secret Text credential for posting messages. Overrides webhook token text.">
+            <c:select value="${instance.getWebhookTokenCredentialId()}"/>
         </f:entry>
         
         <f:validateButton
                 title="${%Test Connection}" progress="${%Testing...}"
-                method="testConnection" with="rocketChannel,webhookToken"/>
+                method="testConnection" with="rocketChannel,webhookToken,tokenCredentialId"/>
     </f:advanced>
 </j:jelly>


### PR DESCRIPTION
Add field to build for notifying to webhook token rather than username/ password. The sent/ received JSON is identical, so only small client changes and some refactoring was needed.

Also adds credentials dependency currently only for webhook token.