### PR TITLE
Fix for JENKINS-49407

### DIFF
--- a/src/main/resources/jenkins/plugins/rocketchatnotifier/workflow/RocketSendStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/rocketchatnotifier/workflow/RocketSendStep/config.jelly
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:core" xmlns:in="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:core" xmlns:in="jelly:stapler" xmlns:c="/lib/credentials">
   <f:entry field="message" title="Message">
     <f:textbox/>
   </f:entry>
@@ -19,6 +19,12 @@
     </f:entry>
     <f:entry field="failOnError">
       <f:checkbox title="Fail On Error" default="false"/>
+    </f:entry>
+    <f:entry field="webhookToken" title="Incoming Webhook Token" description="Webhook token for posting messages. Overrides global authentication data and channel.">
+      <f:textbox/>
+    </f:entry>
+    <f:entry field="webhookTokenCredentialId" title="Webhook Token Credential ID" name="webhookTokenCredentialId" description="Webhook token as Secret Text credential for posting messages. Overrides webhook token text.">
+      <c:select/>
     </f:entry>
     <f:block>
       <f:entry title="Attachments">

--- a/src/test/java/jenkins/plugins/rocketchatnotifier/workflow/RocketSendTest.java
+++ b/src/test/java/jenkins/plugins/rocketchatnotifier/workflow/RocketSendTest.java
@@ -1,27 +1,30 @@
 package jenkins.plugins.rocketchatnotifier.workflow;
 
-import hudson.model.Run;
-import hudson.model.TaskListener;
-import jenkins.model.Jenkins;
-import jenkins.plugins.rocketchatnotifier.RocketChatNotifier;
-import jenkins.plugins.rocketchatnotifier.RocketClientImpl;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
-import java.io.PrintStream;
-
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyString;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import java.io.PrintStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
+import jenkins.plugins.rocketchatnotifier.RocketChatNotifier;
+import jenkins.plugins.rocketchatnotifier.RocketClientImpl;
+import jenkins.plugins.rocketchatnotifier.RocketClientWebhookImpl;
 
 
 @RunWith(PowerMockRunner.class)
@@ -46,10 +49,14 @@ public class RocketSendTest {
   @Mock
   RocketClientImpl rocketClientMock;
 
+  @Mock
+  RocketClientWebhookImpl rocketWebhookClientMock;
+
   @Before
   public void setUp() throws Exception {
     PowerMockito.mockStatic(Jenkins.class);
     whenNew(RocketClientImpl.class).withAnyArguments().thenReturn(rocketClientMock);
+    whenNew(RocketClientWebhookImpl.class).withAnyArguments().thenReturn(rocketWebhookClientMock);
     when(jenkins.getDescriptorByType(RocketChatNotifier.DescriptorImpl.class)).thenReturn(rocketDescMock);
     when(rocketDescMock.getRocketServerUrl()).thenReturn("rocket.test.com");
     when(rocketDescMock.getUsername()).thenReturn("user");
@@ -68,10 +75,29 @@ public class RocketSendTest {
     when(Jenkins.getInstance()).thenReturn(jenkins);
     // when
     when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
-    when(stepExecution.getRocketClient(anyString(), anyBoolean(), anyString(), anyString(), anyString())).thenReturn(rocketClientMock);
+    when(stepExecution.getRocketClient(anyString(), anyBoolean(), anyString(), anyString(), anyString(), Matchers.isNull(String.class), Matchers.isNull(String.class))).thenReturn(rocketClientMock);
     stepExecution.run();
     // then
-    verify(stepExecution, times(1)).getRocketClient("rocket.test.com", false, "user", "pass", "default");
+    verify(stepExecution, times(1)).getRocketClient("rocket.test.com", false, "user", "pass", "default", null, null);
+  }
+
+  @Test
+  public void shouldWorkWithWebhookParams() throws Exception {
+    // given
+    RocketSendStep.RocketSendStepExecution stepExecution = spy(new RocketSendStep.RocketSendStepExecution());
+    RocketSendStep rocketSendStep = new RocketSendStep("message");
+    rocketSendStep.setWebhookToken("abcdefg0123456789");
+    rocketSendStep.setWebhookTokenCredentialId("webhook-credential-id");
+    stepExecution.step = rocketSendStep;
+    stepExecution.listener = taskListenerMock;
+    stepExecution.run = run;
+    when(Jenkins.getInstance()).thenReturn(jenkins);
+    // when
+    when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
+    when(stepExecution.getRocketClient(anyString(), anyBoolean(), anyString(), anyString(), anyString(), anyString(), anyString())).thenReturn(rocketWebhookClientMock);
+    stepExecution.run();
+    // then
+    verify(stepExecution, times(1)).getRocketClient("rocket.test.com", false, "user", "pass", "default", "abcdefg0123456789", "webhook-credential-id");
   }
 
   @Test
@@ -86,10 +112,10 @@ public class RocketSendTest {
     when(Jenkins.getInstance()).thenReturn(jenkins);
     // when
     when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
-    when(stepExecution.getRocketClient(anyString(), anyBoolean(), anyString(), anyString(), anyString())).thenReturn(rocketClientMock);
+    when(stepExecution.getRocketClient(anyString(), anyBoolean(), anyString(), anyString(), anyString(), anyString(), anyString())).thenReturn(rocketClientMock);
     stepExecution.run();
     // then
-    verify(stepExecution, times(1)).getRocketClient("rocket.test.com", false, "user", "pass", "channel");
+    verify(stepExecution, times(1)).getRocketClient("rocket.test.com", false, "user", "pass", "channel", null, null);
   }
 
 


### PR DESCRIPTION
- Updated the jelly template to include the new webhook parameters.

- Updated RocketSendStep.getRocketClient() to return the correct RocketClient implementation type based in the presence of the webhook parameters.

- Updated the unit tests with a version that handles the Webhook implementation.