### PR TITLE
fix: obey channel parameter for messages sent via webhook

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
@@ -325,7 +325,7 @@ public class RocketChatNotifier extends Notifier {
     password = env.expand(password);
 
     if (!StringUtils.isEmpty(webhookToken) || !StringUtils.isEmpty(webhookTokenCredentialId)) {
-      return new RocketClientWebhookImpl(serverUrl, trustSSL, webhookToken, webhookTokenCredentialId);
+      return new RocketClientWebhookImpl(serverUrl, trustSSL, webhookToken, webhookTokenCredentialId, channel);
     }
     return new RocketClientImpl(serverUrl, trustSSL, username, password, channel);
   }
@@ -518,7 +518,7 @@ public class RocketChatNotifier extends Notifier {
 
         RocketClient rocketChatClient;
         if (!StringUtils.isEmpty(targetWebhookToken) || !StringUtils.isEmpty(targetWebhookTokenCredentialId)) {
-          rocketChatClient = new RocketClientWebhookImpl(targetServerUrl, targetTrustSSL, targetWebhookToken, targetWebhookTokenCredentialId);
+          rocketChatClient = new RocketClientWebhookImpl(targetServerUrl, targetTrustSSL, targetWebhookToken, targetWebhookTokenCredentialId, channel);
         }
         else {
           rocketChatClient = new RocketClientImpl(targetServerUrl, targetTrustSSL, targetUsername, targetPassword, targetChannel);

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/RocketClientWebhookImpl.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/RocketClientWebhookImpl.java
@@ -26,14 +26,17 @@ public class RocketClientWebhookImpl implements RocketClient {
 
   private RocketChatClient client;
 
-  public RocketClientWebhookImpl(String serverUrl, boolean trustSSL, String token, String tokenCredentialId) {
+  private String channel;
+
+  public RocketClientWebhookImpl(String serverUrl, boolean trustSSL, String token, String tokenCredentialId, String channel) {
     client = new RocketChatClientImpl(serverUrl, trustSSL, getTokenToUse(tokenCredentialId, token));
+    this.channel = channel;
   }
 
   public boolean publish(String message) {
     try {
       LOGGER.fine("Starting sending message to webhook");
-      this.client.send("", message);
+      this.client.send(this.channel, message);
       return true;
     } catch (IOException e) {
       LOGGER.log(Level.SEVERE, "I/O error error during publishing message", e);
@@ -48,7 +51,7 @@ public class RocketClientWebhookImpl implements RocketClient {
   public boolean publish(final String message, final String emoji, final String avatar) {
     try {
       LOGGER.fine("Starting sending message to webhook");
-      this.client.send("", message, emoji, avatar);
+      this.client.send(this.channel, message, emoji, avatar);
       return true;
     } catch (IOException e) {
       LOGGER.log(Level.SEVERE, "I/O error error during publishing message", e);
@@ -64,7 +67,7 @@ public class RocketClientWebhookImpl implements RocketClient {
       final List<Map<String, Object>> attachments) {
     try {
       LOGGER.fine("Starting sending message to webhook");
-      this.client.send("", message, emoji, avatar, attachments);
+      this.client.send(this.channel, message, emoji, avatar, attachments);
       return true;
     } catch (IOException e) {
       LOGGER.log(Level.SEVERE, "I/O error error during publishing message", e);

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/workflow/RocketSendStep.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/workflow/RocketSendStep.java
@@ -251,7 +251,7 @@ public class RocketSendStep extends AbstractStepImpl {
     RocketClient getRocketClient(String server, boolean trustSSL, String user, String password, String channel,
       String webhookToken, String webhookTokenCredentialId) throws IOException {
       if (!StringUtils.isEmpty(webhookToken) || !StringUtils.isEmpty(webhookTokenCredentialId)) {
-        return new RocketClientWebhookImpl(server, trustSSL, webhookToken, webhookTokenCredentialId);
+        return new RocketClientWebhookImpl(server, trustSSL, webhookToken, webhookTokenCredentialId, channel);
       }
       return new RocketClientImpl(server, trustSSL, user, password, channel);
     }


### PR DESCRIPTION
Setting the `channel` parameter did not have any effect when using `RocketClientWebhookImpl` as client

## Changes
* `channel` parameter is now picked up when sending messages via webhooks to RocketChat