### PR TITLE
Add correct link to plugin docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
   <artifactId>rocketchatnotifier${artifactSuffix}</artifactId>
   <version>1.2.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
+  <url>https://plugins.jenkins.io/rocketchatnotifier</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
Adding link to plugin page. It is missing now what is likely causing it to be inherited from plugin pom so on the plugin page itself[1] the link to git leads to https://github.com/jenkinsci/plugin-pom. The same in the update center metadata[2].

[1] https://plugins.jenkins.io/rocketchatnotifier
[2] https://updates.jenkins-ci.org/current/update-center.json