### PR TITLE
Fix Proxy detection with nested URIs and different Ports

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/utils/NetworkUtils.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/utils/NetworkUtils.java
@@ -2,6 +2,7 @@ package jenkins.plugins.rocketchatnotifier.utils;
 
 import hudson.ProxyConfiguration;
 
+import java.net.URI;
 import java.util.regex.Pattern;
 
 public class NetworkUtils {
@@ -16,7 +17,7 @@ public class NetworkUtils {
   public static boolean isHostOnNoProxyList(String host, ProxyConfiguration proxy) {
     if (host != null && proxy.noProxyHost != null) {
       for (Pattern p : ProxyConfiguration.getNoProxyHostPatterns(proxy.noProxyHost)) {
-        if (p.matcher(host.replaceFirst("^(http[s]?://www\\.|http[s]?://|www\\.)", "")).matches()) {
+        if (p.matcher(URI.create(host).getHost()).matches()) {
           return true;
         }
       }

--- a/src/test/java/jenkins/plugins/rocketchatnotifier/utils/BuildUtilsTest.java
+++ b/src/test/java/jenkins/plugins/rocketchatnotifier/utils/BuildUtilsTest.java
@@ -16,7 +16,7 @@ import static org.mockito.BDDMockito.given;
 public class BuildUtilsTest {
 
   @Mock
-  private Run<?, ?> run;
+  private Run run;
   @Mock
   private Run firstRun;
   @Mock

--- a/src/test/java/jenkins/plugins/rocketchatnotifier/utils/NetworkUtilsTest.java
+++ b/src/test/java/jenkins/plugins/rocketchatnotifier/utils/NetworkUtilsTest.java
@@ -40,6 +40,9 @@ public class NetworkUtilsTest {
       {new ProxyConfiguration("sample1", 1234, null, null, "*.test.*|localhost"), "http://rocket.test.com", true},
       {new ProxyConfiguration("sample1", 1234, null, null, "rocket.test.com"), "http://rocket.test.com", true},
       {new ProxyConfiguration("sample1", 1234, null, null, "rocket.test.com"), "https://rocket.test.com", true},
+      {new ProxyConfiguration("sample1", 1234, null, null, "rocket.test.com"), "https://rocket.test.com:8443", true},
+      {new ProxyConfiguration("sample1", 1234, null, null, "rocket.test.com"), "https://rocket.test.com/nestedUrl", true},
+      {new ProxyConfiguration("sample1", 1234, null, null, "rocket.test.com"), "https://rocket.test.com:8443/nestedUrl", true},
       {new ProxyConfiguration("sample1", 1234, null, null, "*.test.com|localhost"), "http://rocket.test2.com", false},
 
     });


### PR DESCRIPTION
* Proxy detection was broken for ports other than default
* Proxy detection was broken for URIs with nested installation of rocketchat
this adds a Testcase for this and fixes the detection