### PR TITLE
fix(model/MessageAttachment): Change type string to boolean

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/model/MessageAttachment.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/model/MessageAttachment.java
@@ -43,7 +43,7 @@ public class MessageAttachment extends AbstractDescribableImpl<MessageAttachment
   @JsonProperty("title_link")
   private String titleLink;
   @JsonProperty("title_link_download")
-  private String titleLinkDownload;
+  private Boolean titleLinkDownload;
   @JsonProperty("image_url")
   private String imageUrl;
   @JsonProperty("audio_url")
@@ -151,13 +151,15 @@ public class MessageAttachment extends AbstractDescribableImpl<MessageAttachment
     this.titleLink = titleLink;
   }
 
-  public String getTitleLinkDownload() {
+  public Boolean getTitleLinkDownload() {
     return titleLinkDownload;
   }
 
   @DataBoundSetter
-  public void setTitleLinkDownload(final String titleLinkDownload) {
-    this.titleLinkDownload = titleLinkDownload;
+  public void setTitleLinkDownload(final Boolean titleLinkDownload) {
+    if (titleLinkDownload) {
+      this.titleLinkDownload = titleLinkDownload;
+    }
   }
 
   public String getImageUrl() {
@@ -199,7 +201,7 @@ public class MessageAttachment extends AbstractDescribableImpl<MessageAttachment
     attachment.setAuthorIcon(sanitizeEmptyStringtoNull(json.getString("authorIcon")));
     attachment.setAuthorLink(sanitizeEmptyStringtoNull(json.getString("authorLink")));
     attachment.setTitleLink(sanitizeEmptyStringtoNull(json.getString("titleLink")));
-    attachment.setTitleLinkDownload(sanitizeEmptyStringtoNull(json.getString("titleLinkDownload")));
+    attachment.setTitleLinkDownload(json.getBoolean("titleLinkDownload"));
     attachment.setImageUrl(sanitizeEmptyStringtoNull(json.getString("imageUrl")));
     attachment.setAudioUrl(sanitizeEmptyStringtoNull(json.getString("audioUrl")));
     attachment.setVideoUrl(sanitizeEmptyStringtoNull(json.getString("videoUrl")));

--- a/src/main/resources/jenkins/plugins/rocketchatnotifier/model/MessageAttachment/config.jelly
+++ b/src/main/resources/jenkins/plugins/rocketchatnotifier/model/MessageAttachment/config.jelly
@@ -33,7 +33,7 @@
       <f:textbox/>
     </f:entry>
     <f:entry field="titleLinkDownload" title="title_link_download">
-      <f:textbox/>
+      <f:checkbox/>
     </f:entry>
     <f:entry field="imageUrl" title="image_url">
       <f:textbox/>

--- a/src/test/java/jenkins/plugins/rocketchatnotifier/model/MessageAttachmentTest.java
+++ b/src/test/java/jenkins/plugins/rocketchatnotifier/model/MessageAttachmentTest.java
@@ -42,7 +42,7 @@ public class MessageAttachmentTest {
     messageAttachment.setAuthorIcon("AuthorIcon");
     messageAttachment.setAuthorLink("AuthorLink");
     messageAttachment.setTitleLink("titleLink");
-    messageAttachment.setTitleLinkDownload("titleLinkDownload");
+    messageAttachment.setTitleLinkDownload(false);
     messageAttachment.setImageUrl("imageUrl");
     messageAttachment.setAudioUrl("audioUrl");
     messageAttachment.setVideoUrl("videoUrl");


### PR DESCRIPTION
Hi,

I reported this issue https://issues.jenkins-ci.org/browse/JENKINS-53429.
Here is the fix 😃 .

Regards,