### PR TITLE
fix(RocketChatNotifier): use JenkinsLocationConfiguration.get() (JENKINS-59153)

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
@@ -78,8 +78,7 @@ public class RocketChatNotifier extends Notifier {
   public String getBuildServerUrl() {
     LOGGER.log(Level.FINE, "Getting build server URL");
     if (buildServerUrl == null || buildServerUrl.equalsIgnoreCase("")) {
-      JenkinsLocationConfiguration jenkinsConfig = new JenkinsLocationConfiguration();
-      return jenkinsConfig.getUrl();
+      return JenkinsLocationConfiguration.get().getUrl();
     }
     else {
       return buildServerUrl;

--- a/src/test/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifierTest.java
+++ b/src/test/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifierTest.java
@@ -4,6 +4,8 @@ import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import jenkins.model.Jenkins;
+import jenkins.model.JenkinsLocationConfiguration;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,6 +17,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -22,8 +25,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class, RocketClientImpl.class, RocketClientWebhookImpl.class, RocketChatNotifier.class})
+@PrepareForTest({Jenkins.class, JenkinsLocationConfiguration.class, RocketClientImpl.class, RocketClientWebhookImpl.class, RocketChatNotifier.class})
 public class RocketChatNotifierTest {
+
+  private static final String EXPECTED_URL = "rocket.example.com";
 
   @Mock
   private Jenkins jenkins;
@@ -45,16 +50,14 @@ public class RocketChatNotifierTest {
   @Before
   public void setup() throws Exception {
     MockitoAnnotations.initMocks(this);
-    PowerMockito.mockStatic(Jenkins.class);
-    PowerMockito.mock(RocketClientImpl.class);
-    PowerMockito.mock(RocketClientWebhookImpl.class);
+    PowerMockito.mockStatic(Jenkins.class, JenkinsLocationConfiguration.class);
     PowerMockito.whenNew(RocketClientImpl.class).withAnyArguments().thenReturn(rocketClient);
     PowerMockito.whenNew(RocketClientWebhookImpl.class).withAnyArguments().thenReturn(rocketClientWithWebhook);
     PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
     File rootPath = new File(System.getProperty("java.io.tmpdir"));
     when(jenkins.getRootDir()).thenReturn(rootPath);
     notifier = new RocketChatNotifier(
-      "rocket.example.com", false,
+      EXPECTED_URL, false,
       "user", "password",
       "jenkins", "rocket.example.com",
       false,
@@ -65,9 +68,13 @@ public class RocketChatNotifierTest {
   public void shouldFallbackToJenkinsUrlIfBuildServerUrlIsNotProvived() throws Exception {
     // given
     notifier.setBuildServerUrl(null);
+    JenkinsLocationConfiguration locationConfigMock = PowerMockito.mock(JenkinsLocationConfiguration.class);
+    PowerMockito.when(locationConfigMock.getUrl()).thenReturn(EXPECTED_URL);
+    PowerMockito.when(JenkinsLocationConfiguration.get()).thenReturn(locationConfigMock);
     // when
-    notifier.getBuildServerUrl();
+    String serverUrl = notifier.getBuildServerUrl();
     // then
+    assertThat(serverUrl, equalTo(EXPECTED_URL));
   }
 
   @Test
@@ -76,7 +83,7 @@ public class RocketChatNotifierTest {
     // when
     String serverUrl = notifier.getBuildServerUrl();
     // then
-    assertThat(serverUrl, is(not(nullValue())));
+    assertThat(serverUrl, equalTo(EXPECTED_URL));
   }
 
   @Test


### PR DESCRIPTION
Fixes the finding from https://issues.jenkins-ci.org/browse/JENKINS-59153 but I am not certain that this actually fixes the sporadic `null` issues.