### PR TITLE
fix(deps) Fix enforcer failure due to credentials upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,13 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
       <version>${jenkins-plugins-junit.version}</version>
+      <exclusions>
+        <!-- newer structs version is brought in by non-test dependencies, so exclude it here -->
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>structs</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -282,7 +289,9 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.2.0</version>
+      <!-- must *not* use 2.2.0 here, otherwise enforcer will fail with:
+           Restricted to JDK 1.7 yet org.jenkins-ci.plugins:credentials:jar:2.2.0:compile contains com/cloudbees/plugins/credentials/BaseCredentials.class targeted to JDK 8 -->
+      <version>2.1.19</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Fixes Maven enforcer failures caused by #40:
- `structs` mismatch: 
  ```
  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce (display-info) on project rocketchatnotifier: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]
  [ERROR] 
  [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
  [ERROR] Re-run Maven using the -X switch to enable full debug logging.
  [ERROR] 
  [ERROR] For more information about the errors and possible solutions, please read the following articles:
  [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
  
  The command "mvn clean package --quiet" exited with 1.
  
  [...]
  
  [WARNING] Rule 2: org.apache.maven.plugins.enforcer.EnforceBytecodeVersion failed with message:
  Found Banned Dependency: org.jenkins-ci.plugins:credentials:jar:2.2.0
  Use 'mvn dependency:tree' to locate the source of the banned dependencies.
  [WARNING] Rule 4: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
  Failed while enforcing RequireUpperBoundDeps. The error(s) are [
  Require upper bound dependencies error for org.jenkins-ci.plugins:structs:1.2 paths to dependency are:
  +-org.jenkins-ci.plugins:rocketchatnotifier:1.4.4-SNAPSHOT
    +-org.jenkins-ci.plugins:junit:1.21
      +-org.jenkins-ci.plugins:structs:1.2
  and
  +-org.jenkins-ci.plugins:rocketchatnotifier:1.4.4-SNAPSHOT
    +-org.jenkins-ci.plugins:credentials:2.2.0
      +-org.jenkins-ci.plugins:structs:1.7
  ]
  ```

- JDK-compliance of `credentials:2.2.0`: 
  ```
  [INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (display-info) @ rocketchatnotifier ---
  [INFO] Adding ignore: module-info
  [INFO] Restricted to JDK 1.7 yet org.jenkins-ci.plugins:credentials:jar:2.2.0:compile contains com/cloudbees/plugins/credentials/BaseCredentials.class targeted to JDK 8
  [INFO] Ignoring requireUpperBoundDeps in commons-logging:commons-logging
  [WARNING] Rule 2: org.apache.maven.plugins.enforcer.EnforceBytecodeVersion failed with message:
  Found Banned Dependency: org.jenkins-ci.plugins:credentials:jar:2.2.0
  Use 'mvn dependency:tree' to locate the source of the banned dependencies.
  [INFO] ------------------------------------------------------------------------
  [INFO] BUILD FAILURE
  ```