### PR TITLE
Add error string to response for further logging

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/model/Response.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/model/Response.java
@@ -11,6 +11,7 @@ public class Response {
   private User user;
   private Room[] channels;
   private Room channel;
+  private String error;
 
   public void setSuccess(boolean result) {
     this.success = result;
@@ -80,6 +81,14 @@ public class Response {
     this.version = version;
   }
 
+  public String getError() {
+    return error;
+  }
+
+  public void setError(String error) {
+    this.error = error;
+  }
+
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
@@ -91,6 +100,7 @@ public class Response {
       .add("channels", channels)
       .add("channel", channel)
       .add("version", version)
+      .add("error", error)
       .toString();
   }
 }

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatClientImpl.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatClientImpl.java
@@ -181,7 +181,7 @@ public class RocketChatClientImpl implements RocketChatClient {
       LOG.fine("Message sent was successfull.");
     } else {
       LOG.severe("Could not send message: " + res);
-      throw new RocketClientException("The send of the message was unsuccessful.");
+      throw new RocketClientException("The send of the message was unsuccessful. " + res);
     }
   }
 


### PR DESCRIPTION
This Pull Requests adds the error string to the response, so that it can be used later for further logging.

Background:
We sent messages to our rocket chat server using a user with guest permissions. When sending notifications from our pipelines, where we were overwriting the avatar, this lead to a permission problem:

```
rocketSend avatar: 'https://rocketchat.server/emoji-custom/success.png', channel: 'test-jenkins', message: "test - Branch ${env.BRANCH_NAME} - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)"
```

There were no further infos in the jenkins log. The permission probelm was only visible when debugging the plugin manually: `{"success":false,"error":"You are not authorized to change message properties"}`


