### PR TITLE
Fixes not being able to save custom message [JENKINS-59503]

### DIFF
--- a/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/config.jelly
@@ -46,7 +46,7 @@
             <f:checkbox name="rawMessage" value="true" checked="${instance.isRawMessage()}"/>
         </f:entry>
 
-        <f:optionalBlock name="includeCustomMessage" title="Include Custom Message" checked="${instance.includeCustomMessage()}">
+        <f:optionalBlock name="includeCustomMessage" title="Include Custom Message" inline="true" checked="${instance.includeCustomMessage()}">
             <f:entry title="Custom Message">
                 <f:textarea name="customMessage" value="${instance.getCustomMessage()}"/>
             </f:entry>


### PR DESCRIPTION
If the inline is not present the JSON sent is
"includeCustomMessage":{"customMessage": "testing"}
this cannot be parsed because includeCustomMessage should be a boolean.

When using the inline the JSON is (as expected):
"includeCustomMessage": "true"
"customMessage": "testing"