### PR TITLE
Use README from GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -369,10 +369,10 @@
 
   <ciManagement>
     <system>Jenkins</system>
-    <url>https://jenkins.ci.cloudbees.com/job/plugins/job/rocketchatnotifier-plugin/</url>
+    <url>https://ci.jenkins.io/job/Plugins/job/rocketchatnotifier-plugin/</url>
   </ciManagement>
 
-  <url>https://plugins.jenkins.io/rocketchatnotifier</url>
+  <url>https://github.com/jenkinsci/rocketchatnotifier-plugin/blob/develop/README.md</url>
 
   <developers>
     <developer>


### PR DESCRIPTION
Also updates the CI server URL to the public CI instance

As configured now, the documentation URL points to the plugins site.  The plugin site displays documentation from its original source.  In the case of this plugin, the original source is the README file, not the plugins site.