### PR TITLE
[JENKINS-66427] Prepare RocketChat Notifier for core Guava upgrade

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/model/Message.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/model/Message.java
@@ -1,13 +1,10 @@
 package jenkins.plugins.rocketchatnotifier.model;
 
-import com.google.common.base.Objects;
-
 public class Message {
 
   private String msg;
 
-  public Message() {
-  }
+  public Message() {}
 
   public Message(String messsage) {
     this.msg = messsage;
@@ -23,8 +20,6 @@ public class Message {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("msg", msg)
-      .toString();
+    return "Message{msg=" + msg + "}";
   }
 }

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/model/Response.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/model/Response.java
@@ -1,6 +1,6 @@
 package jenkins.plugins.rocketchatnotifier.model;
 
-import com.google.common.base.Objects;
+import java.util.Arrays;
 
 public class Response {
   private boolean success;
@@ -91,16 +91,25 @@ public class Response {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-      .add("success", success)
-      .add("messages", messages)
-      .add("message", message)
-      .add("users", users)
-      .add("user", user)
-      .add("channels", channels)
-      .add("channel", channel)
-      .add("version", version)
-      .add("error", error)
-      .toString();
+    return "Response{"
+        + "success="
+        + success
+        + ", messages="
+        + Arrays.toString(messages)
+        + ", message="
+        + message
+        + ", users="
+        + Arrays.toString(users)
+        + ", user="
+        + user
+        + ", channels="
+        + Arrays.toString(channels)
+        + ", channel="
+        + channel
+        + ", version="
+        + version
+        + ", error="
+        + error
+        + "}";
   }
 }


### PR DESCRIPTION
See [JENKINS-66427](https://issues.jenkins.io/browse/JENKINS-66427) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.base.Objects#toStringHelper` method, which existed in Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/base/Objects.html) but was [removed in later versions](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/base/Objects.html).

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. This PR migrates away from `Objects#toStringHelper` and rewrites the code to use the native functionality provided by the Java Platform.

CC @hypery2k