### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
 def configurations = [
         [ platform: "linux", jdk: "8", jenkins: null ],
-        //[ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ]
+        //[ platform: "linux", jdk: "11", jenkins: null ]
 ]
 buildPlugin(configurations: configurations, useContainerAgent: true)


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.