### PR TITLE
Fix SCM GitHub repository URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <description>Rocket Chat Notification Plugin for Jenkins</description>
 
   <properties>
-    <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.387.3</jenkins.version>
     <java.level>8</java.level>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Fix broken GitHub link on plugins.jenkins.io

## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This change fixes an incorrect GitHub repository URL exposed on plugins.jenkins.io.
The plugin page was linking to a non-existent repository (jenkinsci/rocketchatnotifier) due to incorrect SCM metadata.

The SCM configuration now correctly points to the actual repository:
jenkinsci/rocketchatnotifier-plugin.

No functional or runtime behavior is impacted; this change only affects plugin metadata used by plugins.jenkins.io.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

Verified the resolved SCM URL locally using:
`mvn -q -DforceStdout help:evaluate -Dexpression=project.scm.url`
Confirmed the evaluated URL points to https://github.com/jenkinsci/rocketchatnotifier-plugin

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
