### PR TITLE
fix(security): replace deprecated SSL with TLS

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatClientCallBuilder.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatClientCallBuilder.java
@@ -196,7 +196,7 @@ public class RocketChatClientCallBuilder {
   }
 
   private static SSLContext createAlwaysTrustingSSLContext() throws NoSuchAlgorithmException, KeyManagementException {
-    SSLContext sslContext = SSLContext.getInstance("SSL");
+    SSLContext sslContext = SSLContext.getInstance("TLS");
 
     // set up a TrustManager that trusts everything
     sslContext.init(null, new TrustManager[]{new X509TrustManager() {


### PR DESCRIPTION
Use TLS instead of deprecated SSL when creating SSLContext.

This avoids deprecated protocol usage, aligns with modern JVM
security defaults, and prevents security scanner warnings.