### PR TITLE
fix(security): store Rocket.Chat secrets using Jenkins Credentials API

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
@@ -1,6 +1,9 @@
 package jenkins.plugins.rocketchatnotifier;
 
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -9,6 +12,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
+import hudson.model.Item;
 import hudson.security.ACL;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
@@ -25,6 +29,7 @@ import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -67,8 +72,15 @@ public class RocketChatNotifier extends Notifier {
   private String customMessage;
   private boolean rawMessage;
   private List<MessageAttachment> attachments;
+  @Deprecated
   private String webhookToken;
   private String webhookTokenCredentialId;
+
+  /**
+   * Optional Username/Password credential to use for Rocket.Chat login.
+   * Job-level value overrides the global configuration.
+   */
+  private String credentialsId;
 
   @Override
   public DescriptorImpl getDescriptor() {
@@ -168,6 +180,11 @@ public class RocketChatNotifier extends Notifier {
 
   public String getWebhookTokenCredentialId() {
     return webhookTokenCredentialId;
+  }
+
+
+  public String getCredentialsId() {
+    return credentialsId;
   }
 
   public String getRocketServerUrl() {
@@ -312,6 +329,12 @@ public class RocketChatNotifier extends Notifier {
     this.webhookTokenCredentialId = webhookTokenCredentialId;
   }
 
+
+  @DataBoundSetter
+  public void setCredentialsId(String credentialsId) {
+    this.credentialsId = credentialsId;
+  }
+
   @DataBoundConstructor
   public RocketChatNotifier() {
     super();
@@ -389,6 +412,25 @@ public class RocketChatNotifier extends Notifier {
     if (StringUtils.isEmpty(serverUrl)) {
       serverUrl = getDescriptor().getRocketServerUrl();
     }
+
+    String channel = this.channel;
+    if (StringUtils.isEmpty(channel)) {
+      channel = getDescriptor().getChannel();
+    }
+
+    // Webhook token credential ID: job overrides global
+    String webhookTokenCredentialId = this.webhookTokenCredentialId;
+    if (StringUtils.isEmpty(webhookTokenCredentialId)) {
+      webhookTokenCredentialId = getDescriptor().getWebhookTokenCredentialId();
+    }
+
+    // Username/Password credentialsId: job overrides global
+    String credentialsId = this.credentialsId;
+    if (StringUtils.isEmpty(credentialsId)) {
+      credentialsId = getDescriptor().getCredentialsId();
+    }
+
+    // Legacy plaintext support (for backward compatibility / migration only)
     String username = this.username;
     if (StringUtils.isEmpty(username)) {
       username = getDescriptor().getUsername();
@@ -396,14 +438,6 @@ public class RocketChatNotifier extends Notifier {
     String password = this.password;
     if (StringUtils.isEmpty(password)) {
       password = getDescriptor().getPassword();
-    }
-    String channel = this.channel;
-    if (StringUtils.isEmpty(channel)) {
-      channel = getDescriptor().getChannel();
-    }
-    String webhookTokenCredentialId = this.webhookTokenCredentialId;
-    if (StringUtils.isEmpty(webhookTokenCredentialId)) {
-      webhookTokenCredentialId = getDescriptor().getWebhookTokenCredentialId();
     }
     String webhookToken = this.webhookToken;
     if (StringUtils.isEmpty(webhookToken)) {
@@ -417,18 +451,60 @@ public class RocketChatNotifier extends Notifier {
       listener.getLogger().println("Error retrieving environment vars: " + e.getMessage());
       env = new EnvVars();
     }
+
     serverUrl = env.expand(serverUrl);
+    channel = env.expand(channel);
     username = env.expand(username);
     password = env.expand(password);
 
-    return getRocketClient(serverUrl, username, password, channel, webhookToken, webhookTokenCredentialId, trustSSL);
+    return getRocketClient(r.getProject(), serverUrl, username, password, channel, webhookToken, webhookTokenCredentialId, credentialsId, trustSSL);
   }
 
-  public static RocketClient getRocketClient(String serverUrl, String username, String password, String channel, String webhookToken, String webhookTokenCredentialId, boolean trustSSL) throws RocketClientException {
-    if (!StringUtils.isEmpty(webhookToken) || !StringUtils.isEmpty(webhookTokenCredentialId)) {
-      return new RocketClientWebhookImpl(serverUrl, trustSSL, webhookToken, webhookTokenCredentialId, channel);
+  public static RocketClient getRocketClient(
+    Item context,
+    String serverUrl,
+    String username,
+    String password,
+    String channel,
+    String webhookToken,
+    String webhookTokenCredentialId,
+    String credentialsId,
+    boolean trustSSL) throws RocketClientException {
+
+    // Preferred: webhook via Secret Text credential
+    if (StringUtils.isNotEmpty(webhookTokenCredentialId)) {
+      return new RocketClientWebhookImpl(serverUrl, trustSSL, null, webhookTokenCredentialId, channel);
     }
+
+    // Legacy: webhook token stored directly (deprecated; kept for backward compatibility only)
+    if (StringUtils.isNotEmpty(webhookToken)) {
+      return new RocketClientWebhookImpl(serverUrl, trustSSL, webhookToken, null, channel);
+    }
+
+    // Preferred: username/password via Credentials
+    if (StringUtils.isNotEmpty(credentialsId)) {
+      Item lookupContext = context != null ? context : Jenkins.get();
+      StandardUsernamePasswordCredentials c = CredentialsProvider.findCredentialById(
+        credentialsId,
+        StandardUsernamePasswordCredentials.class,
+        lookupContext,
+        Collections.<DomainRequirement>emptyList()
+      );
+      if (c == null) {
+        throw new RocketClientException("Configured credentialsId '" + credentialsId + "' not found or not usable.");
+      }
+      return new RocketClientImpl(serverUrl, trustSSL, c.getUsername(), c.getPassword().getPlainText(), channel);
+    }
+
+    // Legacy: plaintext username/password (deprecated; kept for backward compatibility only)
     return new RocketClientImpl(serverUrl, trustSSL, username, password, channel);
+  }
+
+  /**
+   * Backward compatible overload.
+   */
+  public static RocketClient getRocketClient(String serverUrl, String username, String password, String channel, String webhookToken, String webhookTokenCredentialId, boolean trustSSL) throws RocketClientException {
+    return getRocketClient(null, serverUrl, username, password, channel, webhookToken, webhookTokenCredentialId, null, trustSSL);
   }
 
   @Override
@@ -466,6 +542,7 @@ public class RocketChatNotifier extends Notifier {
     private String password;
     private String channel;
     private String buildServerUrl;
+    @Deprecated
     private String webhookToken;
     private String webhookTokenCredentialId;
 
@@ -518,6 +595,12 @@ public class RocketChatNotifier extends Notifier {
       this.rocketServerUrl = rocketServerUrl;
     }
 
+
+    @DataBoundSetter
+    public void setCredentialsId(String credentialsId) {
+      this.credentialsId = credentialsId;
+    }
+
     @DataBoundSetter
     public void setUsername(String username) {
       this.username = username;
@@ -565,8 +648,12 @@ public class RocketChatNotifier extends Notifier {
     }
 
     @Override
+    @RequirePOST
     public boolean configure(StaplerRequest req, JSONObject json) {
-      req.bindJSON(this, json);
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+      if (json != null) {
+        req.bindJSON(this, json);
+      }
       save();
       return true;
     }
@@ -584,17 +671,42 @@ public class RocketChatNotifier extends Notifier {
                                            @QueryParameter("channel") final String channel,
                                            @QueryParameter("buildServerUrl") final String buildServerUrl,
                                            @QueryParameter("webhookToken") final String token,
-                                           @QueryParameter("webhookTokenCredentialId") final String webhookTokenCredentialId) throws FormException {
+                                           @QueryParameter("webhookTokenCredentialId") final String webhookTokenCredentialId,
+                                           @QueryParameter("credentialsId") final String credentialsId) throws FormException {
       Jenkins.get().checkPermission(Jenkins.ADMINISTER);
       try {
         String targetServerUrl = rocketServerUrl + RocketClientImpl.API_PATH;
         if (StringUtils.isEmpty(rocketServerUrl)) {
-          targetServerUrl = this.rocketServerUrl;
+          targetServerUrl = this.rocketServerUrl + RocketClientImpl.API_PATH;
         }
         boolean targetTrustSSL = this.trustSSL;
         if (StringUtils.isNotEmpty(trustSSL)) {
           targetTrustSSL = BooleanUtils.toBoolean(trustSSL);
         }
+
+        String targetChannel = channel;
+        if (StringUtils.isEmpty(targetChannel)) {
+          targetChannel = this.channel;
+        }
+
+        String targetBuildServerUrl = buildServerUrl;
+        if (StringUtils.isEmpty(targetBuildServerUrl)) {
+          targetBuildServerUrl = this.buildServerUrl;
+        }
+
+        // Prefer webhook via Secret Text credential
+        String targetWebhookTokenCredentialId = webhookTokenCredentialId;
+        if (StringUtils.isEmpty(targetWebhookTokenCredentialId)) {
+          targetWebhookTokenCredentialId = this.webhookTokenCredentialId;
+        }
+
+        // Prefer username/password via credentialsId
+        String targetCredentialsId = credentialsId;
+        if (StringUtils.isEmpty(targetCredentialsId)) {
+          targetCredentialsId = this.credentialsId;
+        }
+
+        // Legacy plaintext fallback (deprecated)
         String targetUsername = username;
         if (StringUtils.isEmpty(targetUsername)) {
           targetUsername = this.username;
@@ -603,29 +715,31 @@ public class RocketChatNotifier extends Notifier {
         if (StringUtils.isEmpty(targetPassword)) {
           targetPassword = this.password;
         }
-        String targetChannel = channel;
-        if (StringUtils.isEmpty(targetChannel)) {
-          targetChannel = this.channel;
-        }
-        String targetBuildServerUrl = buildServerUrl;
-        if (StringUtils.isEmpty(targetBuildServerUrl)) {
-          targetBuildServerUrl = this.buildServerUrl;
-        }
         String targetWebhookToken = token;
         if (StringUtils.isEmpty(targetWebhookToken)) {
           targetWebhookToken = this.webhookToken;
         }
-        String targetWebhookTokenCredentialId = webhookTokenCredentialId;
-        if (StringUtils.isEmpty(targetWebhookTokenCredentialId)) {
-          targetWebhookTokenCredentialId = this.webhookTokenCredentialId;
-        }
 
         RocketClient rocketChatClient;
-        if (!StringUtils.isEmpty(targetWebhookToken) || !StringUtils.isEmpty(targetWebhookTokenCredentialId)) {
-          rocketChatClient = new RocketClientWebhookImpl(targetServerUrl, targetTrustSSL, targetWebhookToken, targetWebhookTokenCredentialId, channel);
+        if (StringUtils.isNotEmpty(targetWebhookTokenCredentialId)) {
+          rocketChatClient = new RocketClientWebhookImpl(targetServerUrl, targetTrustSSL, null, targetWebhookTokenCredentialId, targetChannel);
+        } else if (StringUtils.isNotEmpty(targetWebhookToken)) {
+          rocketChatClient = new RocketClientWebhookImpl(targetServerUrl, targetTrustSSL, targetWebhookToken, null, targetChannel);
+        } else if (StringUtils.isNotEmpty(targetCredentialsId)) {
+          StandardUsernamePasswordCredentials c = CredentialsProvider.findCredentialById(
+            targetCredentialsId,
+            StandardUsernamePasswordCredentials.class,
+            Jenkins.get(),
+            Collections.<DomainRequirement>emptyList()
+          );
+          if (c == null) {
+            return FormValidation.error("Configured credentialsId '%s' not found or not usable.", targetCredentialsId);
+          }
+          rocketChatClient = new RocketClientImpl(targetServerUrl, targetTrustSSL, c.getUsername(), c.getPassword().getPlainText(), targetChannel);
         } else {
           rocketChatClient = new RocketClientImpl(targetServerUrl, targetTrustSSL, targetUsername, targetPassword, targetChannel);
         }
+
         String message = "RocketChat/Jenkins plugin: you're all set on " + targetBuildServerUrl;
         LOGGER.fine("Start validating config");
         rocketChatClient.validate();
@@ -646,27 +760,40 @@ public class RocketChatNotifier extends Notifier {
       }
     }
 
-    public ListBoxModel doFillWebhookTokenCredentialIdItems() {
-      if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
-        return new ListBoxModel();
-      }
+    public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context, @QueryParameter String credentialsId) {
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+      Item lookupContext = context != null ? context : Jenkins.get();
       return new StandardListBoxModel()
-        .withEmptySelection()
-        .withAll(lookupCredentials(
-          StringCredentials.class,
-          Jenkins.get(),
+        .includeEmptyValue()
+        .includeMatchingAs(
           ACL.SYSTEM,
-          Collections.<DomainRequirement>emptyList())
-        );
+          lookupContext,
+          StandardUsernamePasswordCredentials.class,
+          Collections.<DomainRequirement>emptyList(),
+          CredentialsMatchers.always()
+        )
+        .includeCurrentValue(credentialsId);
     }
 
-    //WARN users that they should not use the plain/exposed token, but rather the token credential id
-    public FormValidation doCheckWebhookToken(@QueryParameter String value) {
-      if (StringUtils.isEmpty(value)) {
-        return FormValidation.ok();
+    public ListBoxModel doFillWebhookTokenCredentialIdItems(@AncestorInPath Item context, @QueryParameter String webhookTokenCredentialId) {
+      if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        return new StandardListBoxModel().includeCurrentValue(webhookTokenCredentialId);
       }
-      return FormValidation.warning("Exposing your Integration Token is a security risk. Please use the Webhook Token Credential ID");
+      Item lookupContext = context != null ? context : Jenkins.get();
+      return new StandardListBoxModel()
+        .includeEmptyValue()
+        .includeMatchingAs(
+          ACL.SYSTEM,
+          lookupContext,
+          StringCredentials.class,
+          Collections.<DomainRequirement>emptyList(),
+          CredentialsMatchers.always()
+        )
+        .includeCurrentValue(webhookTokenCredentialId);
     }
+
+
+    
   }
 
   @Deprecated

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/workflow/RocketSendStep.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/workflow/RocketSendStep.java
@@ -1,6 +1,5 @@
 package jenkins.plugins.rocketchatnotifier.workflow;
 
-import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
 
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
@@ -9,9 +8,9 @@ import hudson.AbortException;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Run;
+import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.security.ACL;
-import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import java.util.Collections;
 import java.util.List;
@@ -26,13 +25,13 @@ import jenkins.plugins.rocketchatnotifier.RocketClientImpl;
 import jenkins.plugins.rocketchatnotifier.RocketClientWebhookImpl;
 import jenkins.plugins.rocketchatnotifier.model.MessageAttachment;
 import jenkins.plugins.rocketchatnotifier.rocket.errorhandling.RocketClientException;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -49,8 +48,12 @@ public class RocketSendStep extends AbstractStepImpl {
   private boolean trustSSL;
   private String channel;
   private boolean failOnError;
+  @Deprecated
   private String webhookToken;
   private String webhookTokenCredentialId;
+
+  /** Optional Username/Password credential ID (overrides global if set). */
+  private String credentialsId;
 
   private String emoji;
   private String avatar;
@@ -98,6 +101,10 @@ public class RocketSendStep extends AbstractStepImpl {
 
   public String getWebhookTokenCredentialId() {
     return webhookTokenCredentialId;
+  }
+
+  public String getCredentialsId() {
+    return credentialsId;
   }
 
   public List<MessageAttachment> getAttachments() {
@@ -168,6 +175,11 @@ public class RocketSendStep extends AbstractStepImpl {
   }
 
   @DataBoundSetter
+  public void setCredentialsId(final String credentialsId) {
+    this.credentialsId = Util.fixEmpty(credentialsId);
+  }
+
+  @DataBoundSetter
   public void setUseGlobalWebhookToken(boolean useGlobalWebhookToken) {
     this.useGlobalWebhookToken = useGlobalWebhookToken;
   }
@@ -194,26 +206,36 @@ public class RocketSendStep extends AbstractStepImpl {
       return Messages.RocketSendStepDisplayName();
     }
 
-    public ListBoxModel doFillWebhookTokenCredentialIdItems() {
+    public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context, @QueryParameter String credentialsId) {
       if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
-        return new ListBoxModel();
+        return new StandardListBoxModel().includeCurrentValue(credentialsId);
       }
+      Item lookupContext = context != null ? context : Jenkins.get();
       return new StandardListBoxModel()
-        .withEmptySelection()
-        .withAll(lookupCredentials(
-          StringCredentials.class,
-          Jenkins.get(),
+        .includeEmptyValue()
+        .includeMatchingAs(
           ACL.SYSTEM,
-          Collections.<DomainRequirement>emptyList())
-        );
+          lookupContext,
+          StandardUsernamePasswordCredentials.class,
+          Collections.<DomainRequirement>emptyList(),
+          CredentialsMatchers.always())
+        .includeCurrentValue(credentialsId);
     }
 
-    //WARN users that they should not use the plain/exposed token, but rather the token credential id
-    public FormValidation doCheckWebhookToken(@QueryParameter String value) {
-      if (StringUtils.isEmpty(value)) {
-        return FormValidation.ok();
+    public ListBoxModel doFillWebhookTokenCredentialIdItems(@AncestorInPath Item context, @QueryParameter String webhookTokenCredentialId) {
+      if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        return new StandardListBoxModel().includeCurrentValue(webhookTokenCredentialId);
       }
-      return FormValidation.warning("Exposing your Integration Token is a security risk. Please use the Webhook Token Credential ID");
+      Item lookupContext = context != null ? context : Jenkins.get();
+      return new StandardListBoxModel()
+        .includeEmptyValue()
+        .includeMatchingAs(
+          ACL.SYSTEM,
+          lookupContext,
+          StringCredentials.class,
+          Collections.<DomainRequirement>emptyList(),
+          CredentialsMatchers.always())
+        .includeCurrentValue(webhookTokenCredentialId);
     }
   }
 
@@ -252,6 +274,7 @@ public class RocketSendStep extends AbstractStepImpl {
       boolean trustSSL = step.trustSSL || rocketDesc.isTrustSSL();
       String user = rocketDesc.getUsername();
       String password = rocketDesc.getPassword();
+      String globalCredentialsId = rocketDesc.getCredentialsId();
       String channel = step.channel != null ? step.channel : rocketDesc.getChannel();
       String jenkinsUrl = rocketDesc.getBuildServerUrl();
       String webhookToken;
@@ -263,12 +286,15 @@ public class RocketSendStep extends AbstractStepImpl {
         webhookToken = rocketDesc.getWebhookToken();
         webhookTokenCredentialId = rocketDesc.getWebhookTokenCredentialId();
       }
+
+      // Username/Password credentials override
+      String effectiveCredentialsId = step.getCredentialsId() != null ? step.getCredentialsId() : globalCredentialsId;
       // placing in console log to simplify testing of retrieving values from global config or from step field; also used for tests
       listener.getLogger().println(Messages.RocketSendStepConfig(server, trustSSL, channel, step.message));
 
       // getRocketClient needs to be wrapped inside a try-catch because it can fail too if the target RocketChat server does not behave properly.
       try {
-        RocketClient rocketClient = getRocketClient(server, trustSSL, user, password, channel, webhookToken, webhookTokenCredentialId);
+        RocketClient rocketClient = getRocketClient(run.getParent(), server, trustSSL, user, password, channel, webhookToken, webhookTokenCredentialId, effectiveCredentialsId);
 
         String msg = step.message;
         if (!step.rawMessage) {
@@ -296,12 +322,9 @@ public class RocketSendStep extends AbstractStepImpl {
     }
 
     //streamline unit testing
-    RocketClient getRocketClient(String server, boolean trustSSL, String user, String password, String channel,
-                                 String webhookToken, String webhookTokenCredentialId) throws RocketClientException {
-      if (!StringUtils.isEmpty(webhookToken) || !StringUtils.isEmpty(webhookTokenCredentialId)) {
-        return new RocketClientWebhookImpl(server, trustSSL, webhookToken, webhookTokenCredentialId, channel);
-      }
-      return new RocketClientImpl(server, trustSSL, user, password, channel);
+    RocketClient getRocketClient(Item context, String server, boolean trustSSL, String user, String password, String channel,
+                                 String webhookToken, String webhookTokenCredentialId, String credentialsId) throws RocketClientException {
+      return RocketChatNotifier.getRocketClient(context, server, user, password, channel, webhookToken, webhookTokenCredentialId, credentialsId, trustSSL);
     }
 
   }

--- a/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/config.jelly
@@ -66,6 +66,10 @@
             <f:textbox name="rocketServerUrl" value="${instance.getRocketServerUrl()}"/>
         </f:entry>
 
+        <f:entry title="Credentials (Username/Password) - override global" field="credentialsId" description="If set, overrides global Username/Password credentials.">
+            <c:select value="${instance.getCredentialsId()}"/>
+        </f:entry>
+
         <f:entry title="Trust Server Certificate?" description="If checked, the SSL certificate of the Rocket Server will not be checked">
             <f:checkbox field="trustSSL" name="trustSSL" checked="${instance.isTrustSSL()}"/>
         </f:entry>
@@ -74,16 +78,12 @@
             <f:textbox name="channel" value="${instance.getChannel()}"/>
         </f:entry>
 
-        <f:entry title="Incoming Webhook Token" description="Webhook token for posting messages. Overrides global authentication data and channel.">
-            <f:textbox field="webhookToken" name="webhookToken" value="${instance.getWebhookToken()}"/>
-        </f:entry>
-
         <f:entry title="Webhook Token Credential ID" field="webhookTokenCredentialId" name="webhookTokenCredentialId" description="Webhook token as Secret Text credential for posting messages. Overrides webhook token text.">
             <c:select value="${instance.getWebhookTokenCredentialId()}"/>
         </f:entry>
 
         <f:validateButton
                 title="${%Test Connection}" progress="${%Testing...}"
-                method="testConnection" with="rocketServerUrl,trustSSL,channel,webhookToken,webhookTokenCredentialId"/>
+                method="testConnection" with="rocketServerUrl,trustSSL,channel,webhookTokenCredentialId,credentialsId"/>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/global.jelly
@@ -1,49 +1,38 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
-         xmlns:f="/lib/form">
-  <!--
-    This Jelly script is used to produce the global configuration option.
-
-    Hudson uses a set of tag libraries to provide uniformity in forms.
-    To determine where this tag is defined, first check the namespace URI,
-    and then look under $HUDSON/views/. For example, <f:section> is defined
-    in $HUDSON/views/lib/form/section.jelly.
-
-    It's also often useful to just check other similar scripts to see what
-    tags they use. Views are always organized according to its owner class,
-    so it should be straightforward to find them.
-  -->
+         xmlns:f="/lib/form"
+         xmlns:c="/lib/credentials">
   <f:section title="Global RocketChat Notifier Settings">
     <f:entry title="Rocket Server URL">
       <f:textbox field="rocketServerUrl" clazz="required" name="rocketServerUrl"/>
     </f:entry>
-    <f:entry title="Login Username">
-      <f:textbox field="username" name="username" help="Login of the user. Can also be the user id for token based login"/>
+
+    <f:entry title="Credentials (Username/Password)" description="Stores the Rocket.Chat login securely in Jenkins Credentials.">
+      <c:select field="credentialsId"/>
     </f:entry>
-    <f:entry title="Login password">
-      <f:password field="password" name="password" help="Password of the rocketchat user. Can be also the personal access token"/>
-    </f:entry>
+
     <f:entry title="Channel" description="Comma separated list of rooms (e.g. #project) and / or persons (e.g. @john)">
       <f:textbox field="channel" clazz="required" name="channel" />
     </f:entry>
+
     <f:advanced>
       <f:entry title="Trust Server Certificate?"
                description="If checked, the SSL certificate of the Rocket Server will not be checked">
         <f:checkbox field="trustSSL" name="trustSSL"/>
       </f:entry>
-      <f:entry title="Webhook Token Credential ID">
-        <f:textbox field="webhookTokenCredentialId" name="webhookTokenCredentialId" help="Webhook token as Secret Text credential for posting messages. Overrides webhook token text."/>
+
+      <f:entry title="Webhook Token Credential ID" description="Secret Text credential for posting messages via Incoming Webhook. Overrides login/password credentials.">
+        <c:select field="webhookTokenCredentialId"/>
       </f:entry>
-      <f:entry title="Webhook Token">
-        <f:password field="webhookToken" name="webhookToken" help="As alternative for login/password you can use the webhook token here"/>
-      </f:entry>
+
       <f:entry title="Build Server URL">
         <f:textbox field="buildServerUrl" name="buildServerUrl"/>
       </f:entry>
     </f:advanced>
+
     <f:validateButton
       title="${%Test Connection}" progress="${%Testing...}"
       method="testConnection"
-      with="rocketServerUrl,trustSSL,username,password,channel,buildServerUrl,webhookToken,webhookTokenCredentialId"/>
+      with="rocketServerUrl,trustSSL,channel,buildServerUrl,webhookTokenCredentialId,credentialsId"/>
   </f:section>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/rocketchatnotifier/workflow/RocketSendStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/rocketchatnotifier/workflow/RocketSendStep/config.jelly
@@ -26,10 +26,10 @@
     <f:entry field="failOnError">
       <f:checkbox title="Fail On Error" default="false"/>
     </f:entry>
-    <f:entry field="webhookToken" title="Incoming Webhook Token" description="Webhook token for posting messages. Overrides global authentication data and channel.">
-      <f:textbox/>
+    <f:entry field="credentialsId" title="Credentials (Username/Password)" description="Optional. If set, uses Jenkins Credentials instead of plaintext username/password.">
+      <c:select/>
     </f:entry>
-    <f:entry field="webhookTokenCredentialId" title="Webhook Token Credential ID" name="webhookTokenCredentialId" description="Webhook token as Secret Text credential for posting messages. Overrides webhook token text.">
+<f:entry field="webhookTokenCredentialId" title="Webhook Token Credential ID" name="webhookTokenCredentialId" description="Webhook token as Secret Text credential for posting messages via Incoming Webhook. Overrides credentials.">
       <c:select/>
     </f:entry>
     <f:block>


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This change securely migrates Rocket.Chat plaintext login/password fields to Jenkins' Credentials API.
It adds support for selecting Username/Password credentials at both the global and job level.

Legacy fields (username, password) remain for backward compatibility but are deprecated internally.

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

https://github.com/jenkinsci/rocketchatnotifier-plugin/issues/392

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### :scroll: Example code
```js
rocketSend credentialsId: 'rocketchat-userpass', message: 'Build finished!', channel: '#devops'
``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
