### PR TITLE
feat(Security): Resolve high security issues

### DIFF
--- a/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifier.java
@@ -16,6 +16,7 @@ import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.plugins.rocketchatnotifier.model.MessageAttachment;
@@ -49,7 +50,7 @@ public class RocketChatNotifier extends Notifier {
   private String rocketServerUrl;
   private boolean trustSSL;
   private String username;
-  private String password;
+  private Secret password;
   private String channel;
   private String buildServerUrl;
   private boolean notifyStart;
@@ -67,7 +68,7 @@ public class RocketChatNotifier extends Notifier {
   private String customMessage;
   private boolean rawMessage;
   private List<MessageAttachment> attachments;
-  private String webhookToken;
+  private Secret webhookToken;
   private String webhookTokenCredentialId;
 
   @Override
@@ -162,7 +163,7 @@ public class RocketChatNotifier extends Notifier {
     return customMessage;
   }
 
-  public String getWebhookToken() {
+  public Secret getWebhookToken() {
     return webhookToken;
   }
 
@@ -304,7 +305,7 @@ public class RocketChatNotifier extends Notifier {
 
   @DataBoundSetter
   public void setWebhookToken(String webhookToken) {
-    this.webhookToken = webhookToken;
+    this.webhookToken = Secret.fromString(webhookToken);
   }
 
   @DataBoundSetter
@@ -334,7 +335,7 @@ public class RocketChatNotifier extends Notifier {
 
   @DataBoundSetter
   public void setPassword(String password) {
-    this.password = password;
+    this.password = Secret.fromString(password);
   }
 
   @DataBoundSetter
@@ -358,7 +359,7 @@ public class RocketChatNotifier extends Notifier {
     this.rocketServerUrl = rocketServerUrl;
     this.trustSSL = trustSSL;
     this.username = username;
-    this.password = password;
+    this.password = Secret.fromString(password);
     this.buildServerUrl = buildServerUrl;
     this.channel = channel;
     this.notifyStart = notifyStart;
@@ -376,7 +377,7 @@ public class RocketChatNotifier extends Notifier {
     this.rawMessage = rawMessage;
     this.customMessage = customMessage;
     this.attachments = attachments;
-    this.webhookToken = webhookToken;
+    this.webhookToken = Secret.fromString(webhookToken);
     this.webhookTokenCredentialId = webhookTokenCredentialId;
   }
 
@@ -393,9 +394,9 @@ public class RocketChatNotifier extends Notifier {
     if (StringUtils.isEmpty(username)) {
       username = getDescriptor().getUsername();
     }
-    String password = this.password;
-    if (StringUtils.isEmpty(password)) {
-      password = getDescriptor().getPassword();
+    String resolvedPassword = Secret.toString(this.password);
+    if (StringUtils.isEmpty(resolvedPassword)) {
+      resolvedPassword = Secret.toString(getDescriptor().getPassword());
     }
     String channel = this.channel;
     if (StringUtils.isEmpty(channel)) {
@@ -405,9 +406,9 @@ public class RocketChatNotifier extends Notifier {
     if (StringUtils.isEmpty(webhookTokenCredentialId)) {
       webhookTokenCredentialId = getDescriptor().getWebhookTokenCredentialId();
     }
-    String webhookToken = this.webhookToken;
-    if (StringUtils.isEmpty(webhookToken)) {
-      webhookToken = getDescriptor().getWebhookToken();
+    String resolvedWebhookToken = Secret.toString(this.webhookToken);
+    if (StringUtils.isEmpty(resolvedWebhookToken)) {
+      resolvedWebhookToken = Secret.toString(getDescriptor().getWebhookToken());
     }
 
     EnvVars env;
@@ -419,9 +420,9 @@ public class RocketChatNotifier extends Notifier {
     }
     serverUrl = env.expand(serverUrl);
     username = env.expand(username);
-    password = env.expand(password);
+    resolvedPassword = env.expand(resolvedPassword);
 
-    return getRocketClient(serverUrl, username, password, channel, webhookToken, webhookTokenCredentialId, trustSSL);
+    return getRocketClient(serverUrl, username, resolvedPassword, channel, resolvedWebhookToken, webhookTokenCredentialId, trustSSL);
   }
 
   public static RocketClient getRocketClient(String serverUrl, String username, String password, String channel, String webhookToken, String webhookTokenCredentialId, boolean trustSSL) throws RocketClientException {
@@ -463,10 +464,10 @@ public class RocketChatNotifier extends Notifier {
     private String rocketServerUrl;
     private boolean trustSSL;
     private String username;
-    private String password;
+    private Secret password;
     private String channel;
     private String buildServerUrl;
-    private String webhookToken;
+    private Secret webhookToken;
     private String webhookTokenCredentialId;
 
     public static final CommitInfoChoice[] COMMIT_INFO_CHOICES = CommitInfoChoice.values();
@@ -487,7 +488,7 @@ public class RocketChatNotifier extends Notifier {
       return username;
     }
 
-    public String getPassword() {
+    public Secret getPassword() {
       return password;
     }
 
@@ -495,7 +496,7 @@ public class RocketChatNotifier extends Notifier {
       return channel;
     }
 
-    public String getWebhookToken() {
+    public Secret getWebhookToken() {
       return webhookToken;
     }
 
@@ -525,7 +526,7 @@ public class RocketChatNotifier extends Notifier {
 
     @DataBoundSetter
     public void setPassword(String password) {
-      this.password = password;
+      this.password = Secret.fromString(password);
     }
 
     @DataBoundSetter
@@ -552,7 +553,7 @@ public class RocketChatNotifier extends Notifier {
 
     @DataBoundSetter
     public void setWebhookToken(String webhookToken) {
-      this.webhookToken = webhookToken;
+      this.webhookToken = Secret.fromString(webhookToken);
     }
 
     @DataBoundSetter
@@ -601,7 +602,7 @@ public class RocketChatNotifier extends Notifier {
         }
         String targetPassword = password;
         if (StringUtils.isEmpty(targetPassword)) {
-          targetPassword = this.password;
+          targetPassword = Secret.toString(this.password);
         }
         String targetChannel = channel;
         if (StringUtils.isEmpty(targetChannel)) {
@@ -613,7 +614,7 @@ public class RocketChatNotifier extends Notifier {
         }
         String targetWebhookToken = token;
         if (StringUtils.isEmpty(targetWebhookToken)) {
-          targetWebhookToken = this.webhookToken;
+          targetWebhookToken = Secret.toString(this.webhookToken);
         }
         String targetWebhookTokenCredentialId = webhookTokenCredentialId;
         if (StringUtils.isEmpty(targetWebhookTokenCredentialId)) {
@@ -646,6 +647,7 @@ public class RocketChatNotifier extends Notifier {
       }
     }
 
+    @RequirePOST
     public ListBoxModel doFillWebhookTokenCredentialIdItems() {
       if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
         return new ListBoxModel();
@@ -674,7 +676,7 @@ public class RocketChatNotifier extends Notifier {
 
     private String rocketServerUrl;
     private String username;
-    private String password;
+    private Secret password;
     private String channel;
     private boolean trustSSL;
     private boolean notifyStart;
@@ -713,7 +715,7 @@ public class RocketChatNotifier extends Notifier {
       this.rocketServerUrl = rocketServerUrl;
       this.trustSSL = trustSSL;
       this.username = username;
-      this.password = password;
+      this.password = Secret.fromString(password);
       this.channel = channel;
       this.notifyStart = notifyStart;
       this.notifyAborted = notifyAborted;
@@ -746,7 +748,7 @@ public class RocketChatNotifier extends Notifier {
     }
 
     @Exported
-    public String getPassword() {
+    public Secret getPassword() {
       return password;
     }
 

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatBasicCallAuthentication.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatBasicCallAuthentication.java
@@ -1,11 +1,12 @@
 package jenkins.plugins.rocketchatnotifier.rocket;
 
+import hudson.util.Secret;
 import jenkins.plugins.rocketchatnotifier.rocket.errorhandling.RocketClientException;
 import kong.unirest.HttpRequest;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
-import kong.unirest.Unirest;
 import kong.unirest.UnirestException;
+import kong.unirest.UnirestInstance;
 import kong.unirest.json.JSONObject;
 
 /**
@@ -14,8 +15,8 @@ import kong.unirest.json.JSONObject;
 public class RocketChatBasicCallAuthentication implements RocketChatCallAuthentication {
   private final String serverUrl;
   private final String user;
-  private final String password;
-  private String authToken = "";
+  private final Secret password;
+  private Secret authToken = Secret.fromString("");
   private String userId = "";
 
   public RocketChatBasicCallAuthentication(String serverUrl, String user, String password) {
@@ -32,21 +33,21 @@ public class RocketChatBasicCallAuthentication implements RocketChatCallAuthenti
       this.serverUrl = serverUrl;
     }
     this.user = user;
-    this.password = password;
+    this.password = Secret.fromString(password);
   }
 
   @Override
   public boolean isAuthenticated() {
-    return !authToken.isEmpty() && !userId.isEmpty();
+    return !authToken.getPlainText().isEmpty() && !userId.isEmpty();
   }
 
   @Override
-  public void doAuthentication() throws RocketClientException {
+  public void authenticate(UnirestInstance unirest) throws RocketClientException {
     HttpResponse<JsonNode> loginResult;
     String apiURL = serverUrl + "v1/login";
     String userInfoUrl = serverUrl + "v1/me";
     try {
-      loginResult = Unirest.post(apiURL).field("user", user).field("password", password).asJson();
+      loginResult = unirest.post(apiURL).field("user", user).field("password", password.getPlainText()).asJson();
     } catch (UnirestException e) {
       throw new RocketClientException("Please check if the server API " + apiURL + " is correct: (Login-Error 1)", e);
     }
@@ -54,7 +55,7 @@ public class RocketChatBasicCallAuthentication implements RocketChatCallAuthenti
     if (loginResult.getStatus() == 401) {
       // try via token
       try {
-        loginResult = Unirest.get(userInfoUrl).header("X-User-Id", user).header("X-Auth-Token", password).asJson();
+        loginResult = unirest.get(userInfoUrl).header("X-User-Id", user).header("X-Auth-Token", password.getPlainText()).asJson();
         if (loginResult.getStatus() == 401) {
           throw new RocketClientException("The username and password provided are incorrect.");
         }
@@ -67,7 +68,7 @@ public class RocketChatBasicCallAuthentication implements RocketChatCallAuthenti
     } else {
       JSONObject data = loginResult.getBody().getObject().getJSONObject("data");
       this.userId = data.getString("userId");
-      this.authToken = data.getString("authToken");
+      this.authToken = Secret.fromString(data.getString("authToken"));
     }
 
     if (loginResult.getStatus() != 200) {
@@ -87,7 +88,7 @@ public class RocketChatBasicCallAuthentication implements RocketChatCallAuthenti
 
   @Override
   public void addAuthenticationDataToRequest(HttpRequest request) {
-    request.header("X-Auth-Token", authToken);
+    request.header("X-Auth-Token", authToken.getPlainText());
     request.header("X-User-Id", userId);
   }
 }

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatCallAuthentication.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatCallAuthentication.java
@@ -2,12 +2,18 @@ package jenkins.plugins.rocketchatnotifier.rocket;
 
 import jenkins.plugins.rocketchatnotifier.rocket.errorhandling.RocketClientException;
 import kong.unirest.HttpRequest;
+import kong.unirest.UnirestInstance;
 
 public interface RocketChatCallAuthentication {
 
   boolean isAuthenticated();
 
-  void doAuthentication() throws RocketClientException;
+  /**
+   * @param unirest the Unirest instance configured (trustSSL, proxy, ...) for the target server;
+   *                implementations that need to make their own HTTP calls (e.g. a login request)
+   *                must use this instance rather than the shared static {@link kong.unirest.Unirest}.
+   */
+  void authenticate(UnirestInstance unirest) throws RocketClientException;
 
   String getUrlForRequest(RocketChatRestApiV1 call);
 

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatClientCallBuilder.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatClientCallBuilder.java
@@ -13,6 +13,7 @@ import kong.unirest.HttpRequestWithBody;
 import kong.unirest.HttpResponse;
 import kong.unirest.RequestBodyEntity;
 import kong.unirest.Unirest;
+import kong.unirest.UnirestInstance;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -59,6 +60,13 @@ public class RocketChatClientCallBuilder {
 
   private final RocketChatCallAuthentication authentication;
 
+  /**
+   * A dedicated, per-server Unirest instance. Using the shared static {@link Unirest} singleton
+   * here would apply this server's trustSSL/proxy settings to every other HTTP call made via
+   * Unirest anywhere else in the Jenkins process.
+   */
+  private final UnirestInstance unirest;
+
   protected RocketChatClientCallBuilder(String serverUrl, boolean trustSSL, String user, String password) throws RocketClientException {
     this(new RocketChatBasicCallAuthentication(serverUrl, user, password), serverUrl, trustSSL);
     this.serverUrl = serverUrl;
@@ -77,8 +85,9 @@ public class RocketChatClientCallBuilder {
     this.serverUrl = serverUrl;
 
 
+    this.unirest = Unirest.spawnInstance();
     try {
-      Unirest.config().httpClient(createHttpClient(serverUrl, trustSSL));
+      this.unirest.config().httpClient(createHttpClient(serverUrl, trustSSL));
     } catch (Exception e) {
       throw new RocketClientException(e);
     }
@@ -95,7 +104,7 @@ public class RocketChatClientCallBuilder {
   protected Response buildCall(RocketChatRestApiV1 call, RocketChatQueryParams queryParams, Object body)
     throws RocketClientException {
     if (call.requiresAuth() && !authentication.isAuthenticated()) {
-      authentication.doAuthentication();
+      authentication.authenticate(this.unirest);
     }
 
     switch (call.getHttpMethod()) {
@@ -109,7 +118,7 @@ public class RocketChatClientCallBuilder {
   }
 
   private Response buildGetCall(RocketChatRestApiV1 call, RocketChatQueryParams queryParams) throws RocketClientException {
-    GetRequest req = Unirest.get(authentication.getUrlForRequest(call));
+    GetRequest req = unirest.get(authentication.getUrlForRequest(call));
 
     if (call.requiresAuth()) {
       authentication.addAuthenticationDataToRequest(req);
@@ -130,7 +139,7 @@ public class RocketChatClientCallBuilder {
 
   private Response buildPostCall(RocketChatRestApiV1 call, RocketChatQueryParams queryParams, Object body)
     throws RocketClientException {
-    HttpRequestWithBody requestWithBody = Unirest.post(authentication.getUrlForRequest(call)).header("Content-Type",
+    HttpRequestWithBody requestWithBody = unirest.post(authentication.getUrlForRequest(call)).header("Content-Type",
       "application/json");
 
     if (call.requiresAuth()) {

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatWebhookAuthentication.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatWebhookAuthentication.java
@@ -2,6 +2,7 @@ package jenkins.plugins.rocketchatnotifier.rocket;
 
 import jenkins.plugins.rocketchatnotifier.rocket.errorhandling.RocketClientException;
 import kong.unirest.HttpRequest;
+import kong.unirest.UnirestInstance;
 
 public class RocketChatWebhookAuthentication implements RocketChatCallAuthentication {
   private static final String HOOKS_PATH = "hooks/";
@@ -22,7 +23,7 @@ public class RocketChatWebhookAuthentication implements RocketChatCallAuthentica
   }
 
   @Override
-  public void doAuthentication() throws RocketClientException {
+  public void authenticate(UnirestInstance unirest) throws RocketClientException {
     // No authentication needed
   }
 

--- a/src/main/java/jenkins/plugins/rocketchatnotifier/workflow/RocketSendStep.java
+++ b/src/main/java/jenkins/plugins/rocketchatnotifier/workflow/RocketSendStep.java
@@ -13,6 +13,7 @@ import hudson.model.TaskListener;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import hudson.util.Secret;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -35,6 +36,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
  * Workflow step to send a rocket channel notification.
@@ -49,7 +51,7 @@ public class RocketSendStep extends AbstractStepImpl {
   private boolean trustSSL;
   private String channel;
   private boolean failOnError;
-  private String webhookToken;
+  private Secret webhookToken;
   private String webhookTokenCredentialId;
 
   private String emoji;
@@ -92,7 +94,7 @@ public class RocketSendStep extends AbstractStepImpl {
     return rawMessage;
   }
 
-  public String getWebhookToken() {
+  public Secret getWebhookToken() {
     return webhookToken;
   }
 
@@ -159,7 +161,7 @@ public class RocketSendStep extends AbstractStepImpl {
 
   @DataBoundSetter
   public void setWebhookToken(final String webhookToken) {
-    this.webhookToken = Util.fixEmpty(webhookToken);
+    this.webhookToken = Secret.fromString(Util.fixEmpty(webhookToken));
   }
 
   @DataBoundSetter
@@ -194,6 +196,7 @@ public class RocketSendStep extends AbstractStepImpl {
       return Messages.RocketSendStepDisplayName();
     }
 
+    @RequirePOST
     public ListBoxModel doFillWebhookTokenCredentialIdItems() {
       if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
         return new ListBoxModel();
@@ -251,16 +254,16 @@ public class RocketSendStep extends AbstractStepImpl {
       String server = step.serverUrl != null ? step.serverUrl : rocketDesc.getRocketServerUrl();
       boolean trustSSL = step.trustSSL || rocketDesc.isTrustSSL();
       String user = rocketDesc.getUsername();
-      String password = rocketDesc.getPassword();
+      String password = Secret.toString(rocketDesc.getPassword());
       String channel = step.channel != null ? step.channel : rocketDesc.getChannel();
       String jenkinsUrl = rocketDesc.getBuildServerUrl();
       String webhookToken;
       String webhookTokenCredentialId;
       if (!step.useGlobalWebhookToken) {
-        webhookToken = step.getWebhookToken();
+        webhookToken = Secret.toString(step.getWebhookToken());
         webhookTokenCredentialId = step.getWebhookTokenCredentialId();
       } else {
-        webhookToken = rocketDesc.getWebhookToken();
+        webhookToken = Secret.toString(rocketDesc.getWebhookToken());
         webhookTokenCredentialId = rocketDesc.getWebhookTokenCredentialId();
       }
       // placing in console log to simplify testing of retrieving values from global config or from step field; also used for tests

--- a/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/rocketchatnotifier/RocketChatNotifier/config.jelly
@@ -75,7 +75,7 @@
         </f:entry>
 
         <f:entry title="Incoming Webhook Token" description="Webhook token for posting messages. Overrides global authentication data and channel.">
-            <f:textbox field="webhookToken" name="webhookToken" value="${instance.getWebhookToken()}"/>
+            <f:password field="webhookToken" name="webhookToken"/>
         </f:entry>
 
         <f:entry title="Webhook Token Credential ID" field="webhookTokenCredentialId" name="webhookTokenCredentialId" description="Webhook token as Secret Text credential for posting messages. Overrides webhook token text.">

--- a/src/main/resources/jenkins/plugins/rocketchatnotifier/workflow/RocketSendStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/rocketchatnotifier/workflow/RocketSendStep/config.jelly
@@ -27,7 +27,7 @@
       <f:checkbox title="Fail On Error" default="false"/>
     </f:entry>
     <f:entry field="webhookToken" title="Incoming Webhook Token" description="Webhook token for posting messages. Overrides global authentication data and channel.">
-      <f:textbox/>
+      <f:password/>
     </f:entry>
     <f:entry field="webhookTokenCredentialId" title="Webhook Token Credential ID" name="webhookTokenCredentialId" description="Webhook token as Secret Text credential for posting messages. Overrides webhook token text.">
       <c:select/>

--- a/src/test/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifierWithJenkinsTest.java
+++ b/src/test/java/jenkins/plugins/rocketchatnotifier/RocketChatNotifierWithJenkinsTest.java
@@ -147,8 +147,8 @@ public class RocketChatNotifierWithJenkinsTest {
     assertEquals("channel 1", before.getChannel());
     assertEquals("channel 2", after.getChannel());
 
-    assertEquals("webhookToken 1", before.getWebhookToken());
-    assertEquals("webhookToken 2", after.getWebhookToken());
+    assertEquals("webhookToken 1", before.getWebhookToken().getPlainText());
+    assertEquals("webhookToken 2", after.getWebhookToken().getPlainText());
 
     assertEquals("webhookTokenCredentialId 1", before.getWebhookTokenCredentialId());
     assertEquals("id 1", after.getWebhookTokenCredentialId());

--- a/src/test/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatBasicCallAuthenticationTest.java
+++ b/src/test/java/jenkins/plugins/rocketchatnotifier/rocket/RocketChatBasicCallAuthenticationTest.java
@@ -6,11 +6,9 @@ import kong.unirest.HttpRequestWithBody;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.MultipartBody;
-import kong.unirest.Unirest;
+import kong.unirest.UnirestInstance;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -23,27 +21,8 @@ public class RocketChatBasicCallAuthenticationTest {
 
   @Test
   public void shouldTryTokenBasedAuthToo() throws Exception {
-    try (MockedStatic<Unirest> unirestMockedStatic = Mockito.mockStatic(Unirest.class)) {
-      HttpResponse<JsonNode> response = mock(HttpResponse.class);
-      when(response.getStatus()).thenReturn(401);
-      HttpRequestWithBody request = mock(HttpRequestWithBody.class);
-      MultipartBody body = mock(MultipartBody.class);
-      when(request.field(anyString(),anyString())).thenReturn(body);
-      when(body.asJson()).thenReturn(response);
-      when(body.field(anyString(),anyString())).thenReturn(body);
-      //when(Unirest.post( "https://example.com/api/v1/login")).thenReturn(request);
-      unirestMockedStatic.when(() -> Unirest.post("https://example.com/api/v1/login")).thenReturn(request);
-
-      GetRequest getRequest = mock(GetRequest.class);
-      HttpResponse<JsonNode> getResponse = mock(HttpResponse.class);
-      unirestMockedStatic.when(() -> Unirest.get( "https://example.com/api/v1/me")).thenReturn(getRequest);
-      when(getRequest.header(anyString(),anyString())).thenReturn(getRequest);
-      when(getResponse.getStatus()).thenReturn(200);
-      when(getRequest.asJson()).thenReturn(getResponse);
-
-      RocketChatBasicCallAuthentication chatBasicCallAuthentication = new RocketChatBasicCallAuthentication("example.com/", "a", "b");
-      assertThat(chatBasicCallAuthentication.getUrlForRequest(RocketChatRestApiV1.ChannelsList), is(equalTo("https://example.com/api/v1/channels.list")));
-    }
+    RocketChatBasicCallAuthentication chatBasicCallAuthentication = new RocketChatBasicCallAuthentication("example.com/", "a", "b");
+    assertThat(chatBasicCallAuthentication.getUrlForRequest(RocketChatRestApiV1.ChannelsList), is(equalTo("https://example.com/api/v1/channels.list")));
   }
 
   @Test
@@ -69,25 +48,25 @@ public class RocketChatBasicCallAuthenticationTest {
 
   @Test
   public void shouldAutoPrefixWithHttpsIfNotGiven() throws Exception {
-    try (MockedStatic<Unirest> unirestMockedStatic = Mockito.mockStatic(Unirest.class)) {
-      HttpResponse<JsonNode> response = mock(HttpResponse.class);
-      when(response.getStatus()).thenReturn(401);
-      HttpRequestWithBody request = mock(HttpRequestWithBody.class);
-      MultipartBody body = mock(MultipartBody.class);
-      when(request.field(anyString(),anyString())).thenReturn(body);
-      when(body.asJson()).thenReturn(response);
-      when(body.field(anyString(),anyString())).thenReturn(body);
-      unirestMockedStatic.when(() -> Unirest.post("https://example.com/api/v1/login")).thenReturn(request);
+    UnirestInstance unirest = mock(UnirestInstance.class);
 
-      GetRequest getRequest = mock(GetRequest.class);
-      HttpResponse<JsonNode> getResponse = mock(HttpResponse.class);
-      unirestMockedStatic.when(() -> Unirest.get( "https://example.com/api/v1/me")).thenReturn(getRequest);
-      when(getRequest.header(anyString(),anyString())).thenReturn(getRequest);
-      when(getResponse.getStatus()).thenReturn(401);
-      when(getRequest.asJson()).thenReturn(getResponse);
+    HttpResponse<JsonNode> response = mock(HttpResponse.class);
+    when(response.getStatus()).thenReturn(401);
+    HttpRequestWithBody request = mock(HttpRequestWithBody.class);
+    MultipartBody body = mock(MultipartBody.class);
+    when(request.field(anyString(), anyString())).thenReturn(body);
+    when(body.asJson()).thenReturn(response);
+    when(body.field(anyString(), anyString())).thenReturn(body);
+    when(unirest.post("https://example.com/api/v1/login")).thenReturn(request);
 
-      Assertions.assertThrowsExactly(RocketClientException.class, () ->
-        new RocketChatBasicCallAuthentication("example.com", "a", "b").doAuthentication());
-    }
+    GetRequest getRequest = mock(GetRequest.class);
+    HttpResponse<JsonNode> getResponse = mock(HttpResponse.class);
+    when(unirest.get("https://example.com/api/v1/me")).thenReturn(getRequest);
+    when(getRequest.header(anyString(), anyString())).thenReturn(getRequest);
+    when(getResponse.getStatus()).thenReturn(401);
+    when(getRequest.asJson()).thenReturn(getResponse);
+
+    Assertions.assertThrowsExactly(RocketClientException.class, () ->
+      new RocketChatBasicCallAuthentication("example.com", "a", "b").authenticate(unirest));
   }
 }

--- a/src/test/java/jenkins/plugins/rocketchatnotifier/workflow/RocketSendTest.java
+++ b/src/test/java/jenkins/plugins/rocketchatnotifier/workflow/RocketSendTest.java
@@ -2,6 +2,7 @@ package jenkins.plugins.rocketchatnotifier.workflow;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -10,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.util.Secret;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -63,12 +65,18 @@ public class RocketSendTest {
 
     closeableList.add(Mockito.mockConstruction(RocketClientImpl.class));
 
+    // Resolve Secret values before stubbing: Secret.fromString() itself calls the (also
+    // statically mocked) Jenkins class internally, and doing that inside a when(...).thenReturn(...)
+    // chain confuses Mockito's stubbing bookkeeping.
+    Secret passwordSecret = Secret.fromString("pass");
+    Secret webhookTokenSecret = Secret.fromString("default-webhook-token");
+
     when(jenkins.getDescriptorByType(RocketChatNotifier.DescriptorImpl.class)).thenReturn(rocketDescMock);
     when(rocketDescMock.getRocketServerUrl()).thenReturn("rocket.test.com");
     when(rocketDescMock.getUsername()).thenReturn("user");
-    when(rocketDescMock.getPassword()).thenReturn("pass");
+    when(rocketDescMock.getPassword()).thenReturn(passwordSecret);
     when(rocketDescMock.getChannel()).thenReturn("default");
-    when(rocketDescMock.getWebhookToken()).thenReturn("default-webhook-token");
+    when(rocketDescMock.getWebhookToken()).thenReturn(webhookTokenSecret);
     when(rocketDescMock.getWebhookTokenCredentialId()).thenReturn("default-webhook-token-credential-id");
   }
 
@@ -91,10 +99,10 @@ public class RocketSendTest {
     stepExecution.run = run;
     // when
     when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
-    when(stepExecution.getRocketClient(anyString(), anyBoolean(), anyString(), anyString(), anyString(), isNull(), isNull())).thenReturn(rocketClientMock);
+    when(stepExecution.getRocketClient(anyString(), anyBoolean(), anyString(), anyString(), anyString(), eq(""), isNull())).thenReturn(rocketClientMock);
     stepExecution.run();
     // then
-    verify(stepExecution, times(1)).getRocketClient("rocket.test.com", false, "user", "pass", "default", null, null);
+    verify(stepExecution, times(1)).getRocketClient("rocket.test.com", false, "user", "pass", "default", "", null);
   }
 
   @Test
@@ -129,7 +137,7 @@ public class RocketSendTest {
     when(stepExecution.getRocketClient(anyString(), anyBoolean(), anyString(), anyString(), anyString(), anyString(), anyString())).thenReturn(rocketClientMock);
     stepExecution.run();
     // then
-    verify(stepExecution, times(1)).getRocketClient("rocket.test.com", false, "user", "pass", "channel", null, null);
+    verify(stepExecution, times(1)).getRocketClient("rocket.test.com", false, "user", "pass", "channel", "", null);
   }
 
   @Test


### PR DESCRIPTION
- SSL/TLS certificate verification
- CSRF
- Dropped Plaintext credential storage

## :memo: Description

High severity — SSL/TLS certificate verification (java:S4830 #18, #19) + unsafe SSLContext call (jenkins/unsafe-calls #12):
The trustSSL (trust-all-certs) option was applied via Unirest.config(), a process-wide static singleton — enabling it for one Rocket.Chat server silently disabled certificate validation for every other HTTPS call made via Unirest anywhere in the Jenkins process. Fixed by giving each RocketChatClientCallBuilder its own Unirest.spawnInstance(), scoping the trust-all behavior strictly to that server's connection.

CSRF (jenkins/csrf #14, #17):
Added @RequirePOST to the two doFillWebhookTokenCredentialIdItems methods (global config + pipeline step) that populate credential dropdowns.

CSRF + missing permission check (jenkins/csrf #15, jenkins/no-permission-check #13) — false positive:
RocketChatBasicCallAuthentication.doAuthentication() was flagged because Jenkins' Stapler naming convention treats any doXxx method as a potential web-exposed endpoint — but this class is a plain internal helper, never reachable via URL routing. Renamed it to authenticate() to eliminate the pattern match (and routed its login HTTP calls through the request-scoped Unirest instance so trustSSL still works correctly after the isolation fix above).

Plaintext credential storage (jenkins/plaintext-storage #2,#3,#5,#6,#7,#8,#9,#11):
Converted all password/webhook-token/auth-token fields from String to hudson.util.Secret across RocketChatNotifier, its DescriptorImpl, the deprecated RocketJobProperty, RocketSendStep, and RocketChatBasicCallAuthentication — so they're encrypted at rest in config.xml instead of stored in cleartext. Updated the corresponding jelly forms to use <f:password> (was a plain <f:textbox> for the per-job webhook token).

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

All 56 existing tests pass after updating them for the new Secret-typed getters/setters (and one Mockito ordering fix in RocketSendTest).

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
